### PR TITLE
Restore privilege dropping on exec from suid/sgid process

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -78,10 +78,8 @@ AC_ARG_ENABLE(build-gcov,
     fi
 ])
 
-AC_CHECK_FUNC(setreuid, [], [
-    AC_CHECK_LIB(ucb, setreuid, [if echo $LIBS | grep -- -lucb >/dev/null ;then :; else LIBS="$LIBS -lc -lucb" USEUCB=y;fi])
-])
-AC_CHECK_FUNCS(getuid geteuid iconv mtrace __secure_getenv setregid stpcpy strerror vasprintf srandom)
+AC_SEARCH_LIBS(setreuid, [ucb])
+AC_CHECK_FUNCS(getuid geteuid iconv mtrace __secure_getenv setreuid setuid stpcpy strerror vasprintf srandom)
 
 AM_GNU_GETTEXT_VERSION([0.16.1])
 AM_GNU_GETTEXT([external])

--- a/popt.c
+++ b/popt.c
@@ -498,7 +498,11 @@ static int execCommand(poptContext con)
     rc = setreuid(getuid(), getuid());
     if (rc) goto exit;
 #else
-    ; /* Can't drop privileges */
+    /* refuse to exec if we cannot drop suid/sgid privileges */
+    if (getuid() != geteuid() || getgid() != getegid()) {
+	errno = ENOTSUP;
+	goto exit;
+    }
 #endif
 #endif
 

--- a/poptconfig.c
+++ b/poptconfig.c
@@ -80,7 +80,7 @@ static int poptGlob(UNUSED(poptContext con), const char * pattern,
     if (glob_pattern_p(pat, 0)) {
 	glob_t _g, *pglob = &_g;
 
-	if (!glob(pat, poptGlobFlags, poptGlob_error, pglob)) {
+	if (!(rc = glob(pat, poptGlobFlags, poptGlob_error, pglob))) {
 	    if (acp) {
 		*acp = (int) pglob->gl_pathc;
 		pglob->gl_pathc = 0;
@@ -90,6 +90,10 @@ static int poptGlob(UNUSED(poptContext con), const char * pattern,
 		pglob->gl_pathv = NULL;
 	    }
 	    globfree(pglob);
+	} else if (rc == GLOB_NOMATCH) {
+	    *avp = NULL;
+	    *acp = 0;
+	    rc = 0;
 	} else
 	    rc = POPT_ERROR_ERRNO;
     } else


### PR DESCRIPTION
Commit 30369c3e7e6a7104ac7fb817bf0463b9b03d5053 added ifdef checks for HAVE_SETUID and HAVE_SETREUID in the code of execCommand() in the name of portability, but: there are no checks for either function in configure.ac, so these are never defined and the privilege-dropping code silently falls through to the no-op case and goes on to merrily execute anything at all with possible suid/sgid privileges. Except on HP-UX that is.
    
This means that a suid root application using poptReadDefaultConfig() permits arbitrary command execution by root privileges by simply adding things to $HOME/.popt. Other scenarios also exist.
Affecting all versions of popt over the last 21 years since 1.3 or so.
    
Fix by simply testing for these functions in configure.ac, and replace  a -98 vintage test for setreuid() in libucb by a modern variant. Note how AC_CHECK_FUNCS() was testing for setregid(), not setreuid what the HAVE_     define is on. Also note how we actually tested for setreuid() in various locations, but none of it actually causes HAVE_SETREUID to get defined. FAIL.

Other related commits fix a glob issue which in some cases causes $HOME/.popt not to be read, and refusing to execute with sgid/suid mode at all.