### PR TITLE
Further autofoo cleanups

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@
 
 MCCABE =	pmccabe
 
-EXTRA_DIST = autogen.sh CHANGES $(man_MANS) ci/Dockerfile
+EXTRA_DIST = autogen.sh CHANGES $(man_MANS) ci/Dockerfile build-aux
 
 SUBDIRS = src po auto tests
 

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_CONFIG_SRCDIR([src/popt.h])
 AC_CONFIG_HEADERS([config.h])
 
 dnl Must come before AM_INIT_AUTOMAKE.
-dnl AC_CONFIG_AUX_DIR([build-aux])
+AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([1.10 foreign -Wall])
 

--- a/configure.ac
+++ b/configure.ac
@@ -52,7 +52,7 @@ AC_ARG_ENABLE(build-gcov,
 AC_SEARCH_LIBS(setreuid, [ucb])
 AC_CHECK_FUNCS(getuid geteuid iconv mtrace __secure_getenv setreuid setuid stpcpy strerror vasprintf srandom)
 
-AM_GNU_GETTEXT_VERSION([0.16.1])
+AM_GNU_GETTEXT_VERSION([0.18.2])
 AM_GNU_GETTEXT([external])
 AM_ICONV_LINK
 


### PR DESCRIPTION
Update to newer gettext, use subdir for auxiliary script clutter.