### PR TITLE
system.h cleanups

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ AC_PROG_LIBTOOL
 
 AC_SYS_LARGEFILE
 
-AC_CHECK_HEADERS(float.h fnmatch.h glob.h langinfo.h libintl.h mcheck.h unistd.h)
+AC_CHECK_HEADERS(float.h fnmatch.h glob.h langinfo.h libintl.h mcheck.h)
 
 # For some systems we know that we have ld_version scripts.
 # Use it then as default.

--- a/src/popt.c
+++ b/src/popt.c
@@ -14,6 +14,7 @@
 #include <float.h>
 #endif
 #include <math.h>
+#include <unistd.h>
 
 #include "poptint.h"
 

--- a/src/popt.c
+++ b/src/popt.c
@@ -15,6 +15,8 @@
 #endif
 #include <math.h>
 #include <unistd.h>
+#include <limits.h>
+#include <errno.h>
 
 #include "poptint.h"
 

--- a/src/poptconfig.c
+++ b/src/poptconfig.c
@@ -9,6 +9,7 @@
 #include "system.h"
 #include "poptint.h"
 #include <sys/stat.h>
+#include <unistd.h>
 
 #if defined(HAVE_FNMATCH_H)
 #include <fnmatch.h>

--- a/src/poptconfig.c
+++ b/src/poptconfig.c
@@ -10,6 +10,8 @@
 #include "poptint.h"
 #include <sys/stat.h>
 #include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
 
 #if defined(HAVE_FNMATCH_H)
 #include <fnmatch.h>

--- a/src/poptint.c
+++ b/src/poptint.c
@@ -1,5 +1,6 @@
 #include "system.h"
 #include <stdarg.h>
+#include <errno.h>
 #include "poptint.h"
 
 /* Any pair of 32 bit hashes can be used. lookup3.c generates pairs, will do. */

--- a/src/system.h
+++ b/src/system.h
@@ -11,15 +11,10 @@
 /* XXX isspace(3) has i18n encoding signednesss issues on Solaris. */
 #define	_isspaceptr(_chp)	isspace((int)(*(unsigned char *)(_chp)))
 
-#include <errno.h>
-#include <fcntl.h>
-#include <limits.h>
-
 #ifdef HAVE_MCHECK_H
 #include <mcheck.h>
 #endif
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/system.h
+++ b/src/system.h
@@ -23,16 +23,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(HAVE_UNISTD_H)
-#include <unistd.h>
-#endif
-
-#ifdef __NeXT
-/* access macros are not declared in non posix mode in unistd.h -
- don't try to use posix on NeXTstep 3.3 ! */
-#include <libc.h>
-#endif
-
 void * xmalloc (size_t size);
 
 void * xcalloc (size_t nmemb, size_t size);


### PR DESCRIPTION
Include things where used, not centrally, drop ancient NeXT kludgery.