### PR TITLE
Kludge poptBadOption() to return something semi-meaningful on exec al…

### DIFF
--- a/src/popt.c
+++ b/src/popt.c
@@ -165,6 +165,7 @@ poptContext poptGetContext(const char * name, int argc, const char ** argv,
     con->flags = flags;
     con->execs = NULL;
     con->numExecs = 0;
+    con->execFail = NULL;
     con->finalArgvAlloced = argc * 2;
     con->finalArgv = calloc( (size_t)con->finalArgvAlloced, sizeof(*con->finalArgv) );
     con->execAbsolute = 1;
@@ -206,6 +207,7 @@ void poptResetContext(poptContext con)
     con->nextLeftover = 0;
     con->restLeftover = 0;
     con->doExec = NULL;
+    con->execFail = _free(con->execFail);
 
     if (con->finalArgv != NULL)
     for (i = 0; i < con->finalArgvCount; i++) {
@@ -518,6 +520,9 @@ if (_popt_debug)
 #endif
 
     rc = execvp(argv[0], (char *const *)argv);
+
+    /* only reached on execvp() failure */
+    con->execFail = xstrdup(argv[0]);
 
 exit:
     if (argv) {
@@ -1593,11 +1598,19 @@ int poptAddItem(poptContext con, poptItem newItem, int flags)
 const char * poptBadOption(poptContext con, unsigned int flags)
 {
     struct optionStackEntry * os = NULL;
+    const char *badOpt = NULL;
 
-    if (con != NULL)
-	os = (flags & POPT_BADOPTION_NOALIAS) ? con->optionStack : con->os;
+    if (con != NULL) {
+       /* Stupid hack to return something semi-meaningful from exec failure */
+       if (con->execFail) {
+           badOpt = con->execFail;
+       } else {
+           os = (flags & POPT_BADOPTION_NOALIAS) ? con->optionStack : con->os;
+           badOpt = os->argv[os->next - 1];
+       }
+    }
 
-    return (os != NULL && os->argv != NULL ? os->argv[os->next - 1] : NULL);
+    return badOpt;
 }
 
 const char * poptStrerror(const int error)

--- a/src/poptint.h
+++ b/src/poptint.h
@@ -103,6 +103,7 @@ struct poptContext_s {
     unsigned int flags;
     poptItem execs;
     int numExecs;
+    char * execFail;
     poptArgv finalArgv;
     int finalArgvCount;
     int finalArgvAlloced;


### PR DESCRIPTION
…ias fail

poptBadOption() is totally unaware of exec alias failures, and will return
either the first argument or last option, giving wonderfully misleading
error messages, such as

    $ rpm -q --specfile foo.spec
    rpm: foo.spec: No such file or directory

...when it's the file to be exec'ed that is actually missing. Reported
multiple times, at least
https://bugzilla.redhat.com/show_bug.cgi?id=710267 and
https://bugzilla.redhat.com/show_bug.cgi?id=697435

Remember execvp() first argument on failure and return that from
poptBadOption() if present to give the user more of a reasonable clue
what exactly went wrong.