### PR TITLE
Use secure_getenv() for getenv() if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,7 @@ AC_ARG_ENABLE(build-gcov,
 ])
 
 AC_SEARCH_LIBS(setreuid, [ucb])
-AC_CHECK_FUNCS(getuid geteuid iconv mtrace __secure_getenv setreuid setuid stpcpy strerror vasprintf srandom)
+AC_CHECK_FUNCS(getuid geteuid iconv mtrace secure_getenv __secure_getenv setreuid setuid stpcpy strerror vasprintf srandom)
 
 AM_GNU_GETTEXT_VERSION([0.18.2])
 AM_GNU_GETTEXT([external])

--- a/src/system.h
+++ b/src/system.h
@@ -53,7 +53,9 @@ static inline char * stpcpy (char *dest, const char * src) {
 #define	xstrdup(_str)	strdup(_str)
 #endif  /* defined(HAVE_MCHECK_H) && defined(__GNUC__) */
 
-#if defined(HAVE___SECURE_GETENV)
+#if defined(HAVE_SECURE_GETENV)
+#define getenv(_s)	secure_getenv(_s)
+#elif defined(HAVE___SECURE_GETENV)
 #define	getenv(_s)	__secure_getenv(_s)
 #endif
 


### PR DESCRIPTION
glibc 2.17 renamed __secure_getenv() to secure_getenv(). So now we
need to check for both, meh.