### PR TITLE
Fix the handling of superfluous args

### DIFF
--- a/src/popt.c
+++ b/src/popt.c
@@ -1374,7 +1374,7 @@ int poptGetNextOpt(poptContext con)
 		longArg = expandNextArg(con, longArg);
 		con->os->nextArg = (char *) longArg;
 	    } else if (con->os->nextCharArg) {
-		longArg = expandNextArg(con, con->os->nextCharArg) + (int)(*con->os->nextCharArg == '=');
+		longArg = expandNextArg(con, con->os->nextCharArg + (int)(*con->os->nextCharArg == '='));
 		con->os->nextArg = (char *) longArg;
 		con->os->nextCharArg = NULL;
 	    } else {

--- a/src/popt.h
+++ b/src/popt.h
@@ -92,6 +92,7 @@
 /*@{*/
 #define POPT_ERROR_NOARG	-10	/*!< missing argument */
 #define POPT_ERROR_BADOPT	-11	/*!< unknown option */
+#define POPT_ERROR_UNWANTEDARG	-12	/*!< option does not take an argument */
 #define POPT_ERROR_OPTSTOODEEP	-13	/*!< aliases nested too deeply */
 #define POPT_ERROR_BADQUOTE	-15	/*!< error in paramter quoting */
 #define POPT_ERROR_ERRNO	-16	/*!< errno set, use strerror(errno) */

--- a/tests/test1.c
+++ b/tests/test1.c
@@ -132,7 +132,7 @@ static struct poptOption options[] = {
 	"POPT_BIT_SET: |= 0x7777", 0},
   { "bitclr", '\0', POPT_BIT_CLR | POPT_ARGFLAG_TOGGLE | POPT_ARGFLAG_SHOW_DEFAULT, &aFlag, 0xf842,
 	"POPT_BIT_CLR: &= ~0xf842", 0},
-  { "bitxor", '\0', POPT_ARG_VAL | POPT_ARGFLAG_XOR | POPT_ARGFLAG_SHOW_DEFAULT, &aFlag, (0x8ace^0xfeed),
+  { "bitxor", 'x', POPT_ARG_VAL | POPT_ARGFLAG_XOR | POPT_ARGFLAG_SHOW_DEFAULT, &aFlag, (0x8ace^0xfeed),
 	"POPT_ARGFLAG_XOR: ^= (0x8ace^0xfeed)", 0},
 
   { "nstr", '\0', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT, &nStr, 0,

--- a/tests/testit.sh
+++ b/tests/testit.sh
@@ -121,7 +121,7 @@ Usage: lt-test1 [-I?] [-c|--cb2=STRING] [--arg1] [-2|--arg2=ARG]
         [-L|--longlong=LONGLONG] [-f|--float=FLOAT] [-d|--double=DOUBLE]
         [--randint=INT] [--randshort=SHORT] [--randlong=LONG]
         [--randlonglong=LONGLONG] [--argv=STRING] [--bitset] [--bitclr]
-        [--bitxor] [--nstr=STRING] [--lstr=STRING] [-I|--inc]
+        [-x|--bitxor] [--nstr=STRING] [--lstr=STRING] [-I|--inc]
         [-c|--cb=STRING] [--longopt] [-?|--help] [--usage] [--simple=ARG]" --usage
 run test1 "test1 - 59" "\
 Usage: lt-test1 [OPTION...]
@@ -149,7 +149,7 @@ Usage: lt-test1 [OPTION...]
                                   (can be used multiple times)
       --[no]bitset                POPT_BIT_SET: |= 0x7777
       --[no]bitclr                POPT_BIT_CLR: &= ~0xf842
-      --bitxor                    POPT_ARGFLAG_XOR: ^= (0x8ace^0xfeed)
+  -x, --bitxor                    POPT_ARGFLAG_XOR: ^= (0x8ace^0xfeed)
       --nstr=STRING               POPT_ARG_STRING: (null) (default: null)
       --lstr=STRING               POPT_ARG_STRING: \"123456789...\" (default:
                                   \"This tests default strings and exceeds the
@@ -170,6 +170,9 @@ Options implemented via popt alias/exec:
 Help options:
   -?, --help                      Show this help message
       --usage                     Display brief usage message" --help
+
+run test1 "test1 - 60" "" --val=foo
+run test1 "test1 - 61" "" -x=f1
 
 #run_diff test3 "test3 - 51" test3-data/01.input test3-data/01.answer
 #run_diff test3 "test3 - 52" test3-data/02.input test3-data/02.answer


### PR DESCRIPTION
The popt library does not reject args specified for non-arg command-line options when the arg is attached using '='. For instance, if `--foo` (`-f`) is defined with either POPT_ARG_NONE or POPT_ARG_VAL, then the user should not be able to specify `--foo=ignored` or `-f=misparsed`.  The current code accepts the long-opt version (just ignoring the arg) and parses the short option's arg as if it were a continuation of short options (it just skips the '`=`').

My changes return an error when an arg is attached to either a long or short option when it does not accept an arg. The basic fix has been working great in rsync's built-in version of popt for quite a while (the fix was just not upstreamed for far too long).