### PR TITLE
Detect glob_pattern_p()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,7 @@ AC_ARG_ENABLE(build-gcov,
 ])
 
 AC_SEARCH_LIBS(setreuid, [ucb])
-AC_CHECK_FUNCS(getuid geteuid iconv mtrace secure_getenv __secure_getenv setreuid setuid stpcpy strerror vasprintf srandom)
+AC_CHECK_FUNCS(getuid geteuid iconv mtrace secure_getenv __secure_getenv setreuid setuid stpcpy strerror vasprintf srandom glob_pattern_p)
 
 AM_GNU_GETTEXT_VERSION([0.18.2])
 AM_GNU_GETTEXT([external])

--- a/src/poptconfig.c
+++ b/src/poptconfig.c
@@ -21,7 +21,7 @@
 #if defined(HAVE_GLOB_H)
 #include <glob.h>
 
-#if !defined(__GLIBC__)
+#if !defined(HAVE_GLOB_PATTERN_P)
 /* Return nonzero if PATTERN contains any metacharacters.
    Metacharacters can be quoted with backslashes if QUOTE is nonzero.  */
 static int


### PR DESCRIPTION
The current popt build system tests the existence of <glob.h>, and
then assumes that if __GLIBC__ is defined, then glob_pattern_p() must
be available. Unfortunately, that's not true with uClibc: <glob.h> may
be installed, but not necessarily the GNU glob extensions... and
uClibc defines __GLIBC__. This is causing build issues with certain
uClibc toolchains that do not have GNU glob extensions enabled.

To fix this, this patch adds an AC_CHECK_FUNCS() test for
glob_pattern_p, and uses that to find out whether glob_pattern_p() is
available or not.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
[Retrieved (and slightly updated) from:
https://git.buildroot.net/buildroot/tree/package/popt/0003-glob-detection.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>