### PR TITLE
Add LTLIBICONV to popt.pc.in

### DIFF
--- a/popt.pc.in
+++ b/popt.pc.in
@@ -7,4 +7,5 @@ Name: popt
 Version: @VERSION@
 Description: popt library.
 Libs: -L${libdir} -lpopt
+Libs.private: @LTLIBICONV@
 Cflags: -I${includedir}


### PR DESCRIPTION
Add ${LTLIBICONV} to popt.pc.in so applications such as shairport-sync
will know that they must link with -liconv when building statically

Fixes:
 - http://autobuild.buildroot.org/results/c5b0d1d2867e49c022a2ad971dd9f358ff0f3865

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
[Retrieved (and slightly updated) from:
https://git.buildroot.net/buildroot/tree/package/popt/0004-add-libiconv-to-popt.pc.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>