### PR TITLE
Close iconv in case of allocation error

### DIFF
--- a/src/poptint.c
+++ b/src/poptint.c
@@ -91,8 +91,10 @@ strdup_locale_from_utf8 (char * istr)
 	size_t ob = db;
 	size_t err;
 
-	if (dstr == NULL)
+	if (dstr == NULL) {
+	    (void) iconv_close(cd);
 	    return NULL;
+	}
 	err = iconv(cd, NULL, NULL, NULL, NULL);
 	while (1) {
 	    *pout = '\0';


### PR DESCRIPTION
If memory allocation in strdup_locale_from_utf8 fails after calling
iconv_open, the returned conversion descriptor is not closed.