### PR TITLE
Consider POPT_CONTEXT_KEEP_FIRST during reset.

### DIFF
--- a/src/popt.c
+++ b/src/popt.c
@@ -210,7 +210,10 @@ void poptResetContext(poptContext con)
     con->os->currAlias = NULL;
     con->os->nextCharArg = NULL;
     con->os->nextArg = _free(con->os->nextArg);
-    con->os->next = 1;			/* skip argv[0] */
+    if (!(con->flags & POPT_CONTEXT_KEEP_FIRST))
+	con->os->next = 1;		/* skip argv[0] */
+    else
+	con->os->next = 0;
 
     con->numLeftovers = 0;
     con->nextLeftover = 0;


### PR DESCRIPTION
If context is created with POPT_CONTEXT_KEEP_FIRST flag, then the
first argv entry is parsed as well (argv[0] is normally the program
name).

Calling poptResetContext should reset the context exactly back into
the state in wich it was after poptGetContext.

Unfortunately the "next" value is always set to 1, i.e. pointing
towards argv[1]. Consider POPT_CONTEXT_KEEP_FIRST. If it is set,
point to argv[0] just like poptGetContext does.