### PR TITLE
Treat overly large files on 32 bit systems.

### DIFF
--- a/src/poptconfig.c
+++ b/src/poptconfig.c
@@ -136,13 +136,17 @@ int poptReadFile(const char * fn, char ** bp, size_t * nbp, int flags)
 	goto exit;
 
     if ((nb = lseek(fdno, 0, SEEK_END)) == (off_t)-1
+     || (uintmax_t)nb >= SIZE_MAX
      || lseek(fdno, 0, SEEK_SET) == (off_t)-1
      || (b = calloc(sizeof(*b), (size_t)nb + 1)) == NULL
      || read(fdno, (char *)b, (size_t)nb) != (ssize_t)nb)
     {
 	int oerrno = errno;
 	(void) close(fdno);
-	errno = oerrno;
+	if (nb != (off_t)-1 && (uintmax_t)nb >= SIZE_MAX)
+	    errno = -EOVERFLOW;
+	else
+	    errno = oerrno;
 	goto exit;
     }
     if (close(fdno) == -1)


### PR DESCRIPTION
If a file of 4 GB is opened on a 32 bit system, then an unsigned
overflow leads to insufficient memory allocation and either to
OOB read in poptReadFile or at least a wrong "nb" value returned
by this function.

Set errno to -EOVERFLOW which would lseek do for too large files
as well, e.g. files larger than 4 GB on a 32 bit system without
large file support.