### PR TITLE
fix build without wchar

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ LT_INIT
 
 AC_SYS_LARGEFILE
 
-AC_CHECK_HEADERS([fnmatch.h glob.h langinfo.h libintl.h mcheck.h stdalign.h])
+AC_CHECK_HEADERS([fnmatch.h glob.h langinfo.h libintl.h mcheck.h stdalign.h wchar.h])
 
 # For some systems we know that we have ld_version scripts.
 # Use it then as default.

--- a/src/popthelp.c
+++ b/src/popthelp.c
@@ -15,8 +15,7 @@
 #include <sys/ioctl.h>
 #endif
 
-#define	POPT_WCHAR_HACK
-#ifdef 	POPT_WCHAR_HACK
+#ifdef HAVE_WCHAR_H
 #include <wchar.h>			/* for mbsrtowcs */
 #endif
 #include "poptint.h"
@@ -118,7 +117,7 @@ static size_t maxColumnWidth(FILE *fp)
 static inline size_t stringDisplayWidth(const char *s)
 {
     size_t n = strlen(s);
-#ifdef	POPT_WCHAR_HACK
+#ifdef HAVE_WCHAR_H
     mbstate_t t;
 
     memset ((void *)&t, 0, sizeof (t));	/* In initial state.  */


### PR DESCRIPTION
Check for `wchar.h` and use `HAVE_WCHAR_H` instead of hardcoding `POPT_WCHAR_HACK` to fix the build with (embedded) toolchains that don't support wchar

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>