### PR TITLE
Warnings

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -19,7 +19,7 @@ RUN dnf -y install \
 COPY . .
 
 RUN ./autogen.sh
-RUN ./configure
+RUN ./configure --enable-werror
 RUN make
 
-CMD make distcheck
+CMD make distcheck DISTCHECK_CONFIGURE_FLAGS=--enable-werror

--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,28 @@ AM_GNU_GETTEXT_VERSION([0.18.2])
 AM_GNU_GETTEXT([external])
 AM_ICONV_LINK
 
+AM_CFLAGS="\
+ -Wall\
+ -Wdeclaration-after-statement\
+ -Wextra\
+ -Wmissing-format-attribute\
+ -Wmissing-noreturn\
+ -Wno-gnu-alignof-expression\
+ -Wpointer-arith\
+ -Wshadow\
+ -Wstrict-prototypes\
+ -Wundef\
+ -Wunused\
+ -Wwrite-strings"
+
+AC_ARG_ENABLE([werror],
+        [AS_HELP_STRING([--enable-werror],
+                [Treat warnings as errors (default: warnings are not errors)])],
+                [enable_werror="$enableval"],
+                [enable_werror=no])
+AS_IF([test "x$enable_werror" = "xyes"], [AM_CFLAGS="$AM_CFLAGS -Werror"])
+AC_SUBST([AM_CFLAGS])
+
 AC_CONFIG_SUBDIRS()
 AC_CONFIG_FILES([ po/Makefile.in
     Doxyfile Makefile src/Makefile popt.pc tests/test-poptrc tests/Makefile

--- a/src/lookup3.c
+++ b/src/lookup3.c
@@ -839,7 +839,7 @@ static void driver2(void)
 			printf("Some bit didn't change: ");
 			printf("%.8x %.8x %.8x %.8x %.8x %.8x  ",
 				e[0],f[0],g[0],h[0],x[0],y[0]);
-			printf("i %d j %d m %d len %d\n", i, j, m, hlen);
+			printf("i %u j %u m %u len %u\n", i, j, m, hlen);
 		    }
 		    if (z == MAXPAIR) goto done;
 		}
@@ -847,8 +847,8 @@ static void driver2(void)
 	}
    done:
 	if (z < MAXPAIR) {
-	    printf("Mix success  %2d bytes  %2d initvals  ",i,m);
-	    printf("required  %d  trials\n", z/2);
+	    printf("Mix success  %2u bytes  %2u initvals  ",i,m);
+	    printf("required  %u  trials\n", z/2);
 	}
     }
     printf("\n");
@@ -922,7 +922,7 @@ static void driver3(void)
 	    x = jlu32l(m, b, len);
 	    y = jlu32l(m, b, len);
 	    if ((ref != x) || (ref != y)) 
-		printf("alignment error: %.8x %.8x %.8x %d %d\n",ref,x,y, h, i);
+		printf("alignment error: %.8x %.8x %.8x %u %u\n",ref,x,y, h, i);
 	}
     }
 }

--- a/src/popt.c
+++ b/src/popt.c
@@ -1515,7 +1515,7 @@ poptItem poptFreeItems(poptItem items, int nitems)
 	    item->argv = _free(item->argv);
 	    item++;
 	}
-	items = _free(items);
+	_free(items);
     }
     return NULL;
 }

--- a/src/popt.c
+++ b/src/popt.c
@@ -645,7 +645,7 @@ static const char *
 expandNextArg(poptContext con, const char * s)
 {
     const char * a = NULL;
-    char *t, *te;
+    char *t, *t_tmp, *te;
     size_t tn = strlen(s) + 1;
     char c;
 
@@ -671,8 +671,11 @@ expandNextArg(poptContext con, const char * s)
 
 	    tn += strlen(a);
 	    {   size_t pos = (size_t) (te - t);
-		if ((t = realloc(t, tn)) == NULL)	/* XXX can't happen */
+		if ((t_tmp = realloc(t, tn)) == NULL) {	/* XXX can't happen */
+		    free(t);
 		    return NULL;
+		}
+		t = t_tmp;
 		te = stpcpy(t + pos, a);
 	    }
 	    continue;
@@ -1565,7 +1568,7 @@ int poptAddAlias(poptContext con, struct poptAlias alias,
 
 int poptAddItem(poptContext con, poptItem newItem, int flags)
 {
-    poptItem * items, item;
+    poptItem * items, item_tmp, item;
     int * nitems;
 
     switch (flags) {
@@ -1582,9 +1585,10 @@ int poptAddItem(poptContext con, poptItem newItem, int flags)
 	break;
     }
 
-    *items = realloc((*items), ((*nitems) + 1) * sizeof(**items));
-    if ((*items) == NULL)
+    item_tmp = realloc((*items), ((*nitems) + 1) * sizeof(**items));
+    if (item_tmp == NULL)
 	return 1;
+    *items = item_tmp;
 
     item = (*items) + (*nitems);
 

--- a/src/popthelp.c
+++ b/src/popthelp.c
@@ -41,7 +41,7 @@ static void displayArgs(poptContext con,
     else
 	poptPrintUsage(con, stdout, 0);
 
-    con = poptFreeContext(con);
+    poptFreeContext(con);
     exit(0);
 }
 

--- a/src/popthelp.c
+++ b/src/popthelp.c
@@ -29,6 +29,7 @@
  * @param arg		(unused)
  * @param data		(unused)
  */
+NORETURN
 static void displayArgs(poptContext con,
 		UNUSED(enum poptCallbackReason foo),
 		struct poptOption * key, 

--- a/src/poptint.c
+++ b/src/poptint.c
@@ -85,6 +85,7 @@ strdup_locale_from_utf8 (char * istr)
 	char * shift_pin = NULL;
 	size_t db = strlen(istr);
 	char * dstr = malloc((db + 1) * sizeof(*dstr));
+	char * dstr_tmp;
 	char * pin = istr;
 	char * pout = dstr;
 	size_t ib = db;
@@ -111,12 +112,16 @@ strdup_locale_from_utf8 (char * istr)
 	    case E2BIG:
 	    {	size_t used = (size_t)(pout - dstr);
 		db *= 2;
-		dstr = realloc(dstr, (db + 1) * sizeof(*dstr));
-		if (dstr != NULL) {
-		    pout = dstr + used;
-		    ob = db - used;
-		    continue;
+		dstr_tmp = realloc(dstr, (db + 1) * sizeof(*dstr));
+		if (dstr_tmp == NULL) {
+		    free(dstr);
+		    (void) iconv_close(cd);
+		    return NULL;
 		}
+		dstr = dstr_tmp;
+		pout = dstr + used;
+		ob = db - used;
+		continue;
 	    }   break;
 	    case EINVAL:
 	    case EILSEQ:

--- a/src/poptint.h
+++ b/src/poptint.h
@@ -33,7 +33,7 @@ typedef struct {
 } pbm_set;
 #define	__PBM_BITS(set)	((set)->bits)
 
-#define	PBM_ALLOC(d)	calloc(__PBM_IX (d) + 1, sizeof(__pbm_bits))
+#define	PBM_ALLOC(d)	calloc(__PBM_IX (d) + 1, sizeof(pbm_set))
 #define	PBM_FREE(s)	_free(s);
 #define PBM_SET(d, s)   (__PBM_BITS (s)[__PBM_IX (d)] |= __PBM_MASK (d))
 #define PBM_CLR(d, s)   (__PBM_BITS (s)[__PBM_IX (d)] &= ~__PBM_MASK (d))

--- a/src/poptparse.c
+++ b/src/poptparse.c
@@ -57,6 +57,7 @@ int poptParseArgvString(const char * s, int * argcPtr, const char *** argvPtr)
     char quote = '\0';
     int argvAlloced = POPT_ARGV_ARRAY_GROW_DELTA;
     const char ** argv = malloc(sizeof(*argv) * argvAlloced);
+    const char ** argv_tmp;
     int argc = 0;
     size_t buflen = strlen(s) + 1;
     char * buf, * bufOrig = NULL;
@@ -88,8 +89,9 @@ int poptParseArgvString(const char * s, int * argcPtr, const char *** argvPtr)
 		buf++, argc++;
 		if (argc == argvAlloced) {
 		    argvAlloced += POPT_ARGV_ARRAY_GROW_DELTA;
-		    argv = realloc(argv, sizeof(*argv) * argvAlloced);
-		    if (argv == NULL) goto exit;
+		    argv_tmp = realloc(argv, sizeof(*argv) * argvAlloced);
+		    if (argv_tmp == NULL) goto exit;
+		    argv = argv_tmp;
 		}
 		argv[argc] = buf;
 	    }
@@ -133,6 +135,7 @@ int poptConfigFileToString(FILE *fp, char ** argstrp,
 {
     char line[999];
     char * argstr;
+    char * argstr_tmp;
     char * p;
     char * q;
     char * x;
@@ -186,8 +189,12 @@ int poptConfigFileToString(FILE *fp, char ** argstrp,
 	    argvlen += (t = (size_t)(q - p)) + (sizeof(" --")-1);
 	    if (argvlen >= maxargvlen) {
 		maxargvlen = (t > maxargvlen) ? t*2 : maxargvlen*2;
-		argstr = realloc(argstr, maxargvlen);
-		if (argstr == NULL) return POPT_ERROR_MALLOC;
+		argstr_tmp = realloc(argstr, maxargvlen);
+		if (argstr_tmp == NULL) {
+		    free(argstr);
+		    return POPT_ERROR_MALLOC;
+		}
+		argstr = argstr_tmp;
 	    }
 	    strcat(argstr, " --");
 	    strcat(argstr, p);
@@ -215,8 +222,12 @@ int poptConfigFileToString(FILE *fp, char ** argstrp,
 	argvlen += t + (sizeof("' --='")-1);
 	if (argvlen >= maxargvlen) {
 	    maxargvlen = (t > maxargvlen) ? t*2 : maxargvlen*2;
-	    argstr = realloc(argstr, maxargvlen);
-	    if (argstr == NULL) return POPT_ERROR_MALLOC;
+	    argstr_tmp = realloc(argstr, maxargvlen);
+	    if (argstr_tmp == NULL) {
+		free(argstr);
+		return POPT_ERROR_MALLOC;
+	    }
+	    argstr = argstr_tmp;
 	}
 	strcat(argstr, " --");
 	strcat(argstr, p);

--- a/src/system.h
+++ b/src/system.h
@@ -64,5 +64,6 @@ static inline char * stpcpy (char *dest, const char * src) {
 #endif
 #define UNUSED(x) x __attribute__((__unused__))
 #define FORMAT(a, b, c) __attribute__((__format__ (a, b, c)))
+#define NORETURN __attribute__((__noreturn__))
 
 #include "popt.h"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,19 +1,26 @@
 # Makefile for popt library.
 
-EXTRA_DIST = testit.sh test-poptrc
+EXTRA_DIST = testit.sh \
+             test-poptrc \
+             test3-data/01.answer \
+             test3-data/01.input \
+             test3-data/02.answer \
+             test3-data/02.input \
+             test3-data/03.answer \
+             test3-data/03.input
 
 AM_CPPFLAGS = -I. -I$(top_srcdir)/src
 
-noinst_PROGRAMS = test1 test2 tdict # test3
+noinst_PROGRAMS = test1 test2 tdict test3
 test1_SOURCES = test1.c
 test1_LDFLAGS = 
 test1_LDADD = $(top_builddir)/src/libpopt.la
 test2_SOURCES = test2.c
 test2_LDFLAGS = 
 test2_LDADD = $(top_builddir)/src/libpopt.la
-#test3_SOURCES = test3.c
-#test3_LDFLAGS = 
-#ltest3_LDADD = $(top_builddir)/src/libpopt.la
+test3_SOURCES = test3.c
+test3_LDFLAGS = 
+test3_LDADD = $(top_builddir)/src/libpopt.la
 tdict_SOURCES = tdict.c
 tdict_LDFLAGS = 
 tdict_LDADD = $(top_builddir)/src/libpopt.la

--- a/tests/test3.c
+++ b/tests/test3.c
@@ -1,8 +1,6 @@
-#include <stdio.h>
-#include <stdlib.h>
 #include <errno.h>
-#include <string.h>
-#include <popt.h>
+
+#include "system.h"
 
 int main (int argc, char **argv) {
     char *out;
@@ -39,6 +37,7 @@ int main (int argc, char **argv) {
 	    printf ("'%s'\n", newargv[j]);
 
 	printf ("\n");
+	free(newargv);
 	free(out);
 	fclose (fp);
     }

--- a/tests/testit.sh
+++ b/tests/testit.sh
@@ -39,10 +39,8 @@ run_diff() {
 }
 
 builddir=`pwd`
-srcdir=$builddir
-cd ${srcdir}
-test1=${builddir}/test1
-echo "Running tests in `pwd`"
+cd ${builddir}
+echo "Running tests in ${builddir}"
 
 #make -q testcases
 
@@ -174,9 +172,13 @@ Help options:
 run test1 "test1 - 60" "" --val=foo
 run test1 "test1 - 61" "" -x=f1
 
-#run_diff test3 "test3 - 51" test3-data/01.input test3-data/01.answer
-#run_diff test3 "test3 - 52" test3-data/02.input test3-data/02.answer
-#run_diff test3 "test3 - 53" test3-data/03.input test3-data/03.answer
+if ! [ -e test3-data ]; then
+  # create symlink for running during 'make distcheck'
+  ln -s "${srcdir}/test3-data" test3-data
+fi
+run_diff test3 "test3 - 1" test3-data/01.input test3-data/01.answer
+run_diff test3 "test3 - 2" test3-data/02.input test3-data/02.answer
+run_diff test3 "test3 - 3" test3-data/03.input test3-data/03.answer
 
 echo ""
 echo "Passed."


### PR DESCRIPTION
* ci: fail on compiler warnings
* Use correct type for calloc size computation
* Use %u format specifier for unsigned integers
* Drop dead assignments of function local variable
* Handle realloc failures
* Mark displayArgs with noreturn
* tests: re-enable test3
* configure: enable some default warnings and add werror option
