### PR TITLE
fix build without mbstate_t

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ LT_INIT
 
 AC_SYS_LARGEFILE
 
-AC_CHECK_HEADERS([fnmatch.h glob.h langinfo.h libintl.h mcheck.h stdalign.h wchar.h])
+AC_CHECK_HEADERS([fnmatch.h glob.h langinfo.h libintl.h mcheck.h stdalign.h])
 
 # For some systems we know that we have ld_version scripts.
 # Use it then as default.
@@ -50,7 +50,7 @@ AC_ARG_ENABLE([build-gcov],
 ])
 
 AC_SEARCH_LIBS([setreuid], [ucb])
-AC_CHECK_FUNCS([getuid geteuid iconv mtrace secure_getenv __secure_getenv setreuid setuid stpcpy strerror vasprintf srandom glob_pattern_p])
+AC_CHECK_FUNCS([getuid geteuid iconv mtrace secure_getenv __secure_getenv setreuid setuid stpcpy strerror vasprintf srandom glob_pattern_p mbsrtowcs])
 
 AM_GNU_GETTEXT_VERSION([0.18.2])
 AM_GNU_GETTEXT([external])

--- a/src/popthelp.c
+++ b/src/popthelp.c
@@ -15,7 +15,7 @@
 #include <sys/ioctl.h>
 #endif
 
-#ifdef HAVE_WCHAR_H
+#ifdef HAVE_MBSRTOWCS
 #include <wchar.h>			/* for mbsrtowcs */
 #endif
 #include "poptint.h"
@@ -117,7 +117,7 @@ static size_t maxColumnWidth(FILE *fp)
 static inline size_t stringDisplayWidth(const char *s)
 {
     size_t n = strlen(s);
-#ifdef HAVE_WCHAR_H
+#ifdef HAVE_MBSRTOWCS
     mbstate_t t;
 
     memset ((void *)&t, 0, sizeof (t));	/* In initial state.  */


### PR DESCRIPTION
Commit 41911aac46d69df6a205af59d60f23a418b0e875 tried to fix build without wchar by checking for the availability of `wchar.h` however some toolchains have `wchar.h` but does not define `mbstate_t` and `mbsrtowcs` so replace `HAVE_WCHAR_H` by `HAVE_MBSRTOWCS`

Fixes:
 - http://autobuild.buildroot.org/results/27f184af35468941173628e5e847a284c0b80d73

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>