### PR TITLE
Pull from Fedora docker registry, and use a stable version

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM registry.fedoraproject.org/fedora:32
 MAINTAINER rpm-maint@lists.rpm.org
 
 WORKDIR /srv/popt


### PR DESCRIPTION
Dockerhub is rate-limiting anonymous downloads (and who could blame them),
lets use a service closer to home.

While at it, use a stable version that can be validated to some degree at
least, in rawhide anything could break any which way on any given day.