### PR TITLE
Fix potential mem leak in poptReadConfigFile()

### DIFF
--- a/src/poptconfig.c
+++ b/src/poptconfig.c
@@ -344,13 +344,15 @@ int poptReadConfigFile(poptContext con, const char * fn)
     char * b = NULL, *be;
     size_t nb = 0;
     const char *se;
-    char *t, *te;
+    char *t = NULL, *te;
     int rc;
 
     if ((rc = poptReadFile(fn, &b, &nb, POPT_READFILE_TRIMNEWLINES)) != 0)
 	return (errno == ENOENT ? 0 : rc);
-    if (b == NULL || nb == 0)
-	return POPT_ERROR_BADCONFIG;
+    if (b == NULL || nb == 0) {
+	rc = POPT_ERROR_BADCONFIG;
+	goto exit;
+    }
 
     if ((t = malloc(nb + 1)) == NULL)
 	goto exit;


### PR DESCRIPTION
While it seems that the actual implementation of poptReadFile()
shouldn't allocate the passed buffer (b) if the number of bytes (nb) is
zero (see the read(2) call in that function), it's still up to the
caller to take care of this resource, so let's just do that by bailing
out via "exit" where the freeing happens.

Found by Coverity.