### PR TITLE
Adopt doxygen for move of sources to subdirectory

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -460,14 +460,14 @@ WARN_LOGFILE           =
 # with spaces.
 
 INPUT                  = \
-                        ./popt.c \
-                        ./popt.h \
-                        ./poptconfig.c \
-                        ./popthelp.c \
-                        ./poptint.c \
-                        ./poptint.h \
-                        ./poptparse.c \
-			./system.h
+                        ./src/popt.c \
+                        ./src/popt.h \
+                        ./src/poptconfig.c \
+                        ./src/popthelp.c \
+                        ./src/poptint.c \
+                        ./src/poptint.h \
+                        ./src/poptparse.c \
+                        ./src/system.h
 
 # If the value of the INPUT tag contains directories, you can use the 
 # FILE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp 

--- a/src/popt.c
+++ b/src/popt.c
@@ -1,5 +1,5 @@
 /** \ingroup popt
- * \file popt/popt.c
+ * @file
  */
 
 /* (C) 1998-2002 Red Hat, Inc. -- Licensing details are in the COPYING

--- a/src/popt.h
+++ b/src/popt.h
@@ -1,4 +1,4 @@
-/** \file popt/popt.h
+/** @file
  * \ingroup popt
  */
 

--- a/src/poptconfig.c
+++ b/src/poptconfig.c
@@ -1,5 +1,5 @@
 /** \ingroup popt
- * \file popt/poptconfig.c
+ * @file
  */
 
 /* (C) 1998-2002 Red Hat, Inc. -- Licensing details are in the COPYING

--- a/src/popthelp.c
+++ b/src/popthelp.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 4 -*- */
 
 /** \ingroup popt
- * \file popt/popthelp.c
+ * @file
  */
 
 /* (C) 1998-2002 Red Hat, Inc. -- Licensing details are in the COPYING

--- a/src/poptint.h
+++ b/src/poptint.h
@@ -1,5 +1,5 @@
 /** \ingroup popt
- * \file popt/poptint.h
+ * @file
  */
 
 /* (C) 1998-2000 Red Hat, Inc. -- Licensing details are in the COPYING

--- a/src/poptparse.c
+++ b/src/poptparse.c
@@ -1,5 +1,5 @@
 /** \ingroup popt
- * \file popt/poptparse.c
+ * @file
  */
 
 /* (C) 1998-2002 Red Hat, Inc. -- Licensing details are in the COPYING

--- a/src/system.h
+++ b/src/system.h
@@ -1,5 +1,5 @@
 /**
- * \file popt/system.h
+ * @file
  */
 
 #ifdef HAVE_CONFIG_H


### PR DESCRIPTION
In Mar 2020, Pull Request #12 forget to change Doxygen as well. Tested via:
```
./autogen.sh
./configure
make doxygen
```
Furthermore, it avoids seven warnings: “the name 'popt/popt.h' supplied as the argument in the \file statement is not an input file” by using `@file` instead. Finally, it fixes a white-space issue (tab versus space) in the file `Doxygen.in`.