### PR TITLE
Bump CI Fedora version to 34, adjust for libtool (?) changes

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:32
+FROM registry.fedoraproject.org/fedora:34
 MAINTAINER rpm-maint@lists.rpm.org
 
 WORKDIR /srv/popt

--- a/tests/testit.sh
+++ b/tests/testit.sh
@@ -113,7 +113,7 @@ run test1 "test1 - 56" "arg1: 0 arg2: (none) aFlag: 0xface" --nobitclr
 run test1 "test1 - 57" "arg1: 0 arg2: (none) aBits: foo,baz" --bits foo,bar,baz,!bar
 
 run test1 "test1 - 58" "\
-Usage: lt-test1 [-I?] [-c|--cb2=STRING] [--arg1] [-2|--arg2=ARG]
+Usage: test1 [-I?] [-c|--cb2=STRING] [--arg1] [-2|--arg2=ARG]
         [-3|--arg3=ANARG] [-onedash] [--optional=STRING] [--val]
         [-i|--int=INT] [-s|--short=SHORT] [-l|--long=LONG]
         [-L|--longlong=LONGLONG] [-f|--float=FLOAT] [-d|--double=DOUBLE]
@@ -122,7 +122,7 @@ Usage: lt-test1 [-I?] [-c|--cb2=STRING] [--arg1] [-2|--arg2=ARG]
         [-x|--bitxor] [--nstr=STRING] [--lstr=STRING] [-I|--inc]
         [-c|--cb=STRING] [--longopt] [-?|--help] [--usage] [--simple=ARG]" --usage
 run test1 "test1 - 59" "\
-Usage: lt-test1 [OPTION...]
+Usage: test1 [OPTION...]
       --arg1                      First argument with a really long
                                   description. After all, we have to test
                                   argument help wrapping somehow, right?


### PR DESCRIPTION
F32 was getting long in the tooth, bump to current stable. Apparently
libtool has removed lt- prefix from libtool wrapper script names in
the meanwhile, adjust the test-suite expectation accordingly.