### PR TITLE
Remove pointless (and now broken) Doxygen grouping

### DIFF
--- a/src/popt.h
+++ b/src/popt.h
@@ -1,5 +1,4 @@
 /** @file
- * \ingroup popt
  */
 
 /* (C) 1998-2000 Red Hat, Inc. -- Licensing details are in the COPYING
@@ -13,10 +12,9 @@
 
 #define POPT_OPTION_DEPTH	10
 
-/** \ingroup popt
+/**
  * \name Arg type identifiers
  */
-/*@{*/
 #define POPT_ARG_NONE		 0U	/*!< no arg */
 #define POPT_ARG_STRING		 1U	/*!< arg will be saved as string */
 #define POPT_ARG_INT		 2U	/*!< arg ==> int */
@@ -43,12 +41,9 @@
 #define POPT_ARG_MASK		0x000000FFU
 #define POPT_GROUP_MASK		0x0000FF00U
 
-/*@}*/
-
-/** \ingroup popt
+/**
  * \name Arg modifiers
  */
-/*@{*/
 #define POPT_ARGFLAG_ONEDASH	0x80000000U  /*!< allow -longoption */
 #define POPT_ARGFLAG_DOC_HIDDEN 0x40000000U  /*!< don't show in help/usage */
 #define POPT_ARGFLAG_STRIP	0x20000000U  /*!< strip this arg from argv(only applies to long args) */
@@ -72,24 +67,19 @@
 #define	POPT_ARGFLAG_RANDOM	0x00400000U  /*!< random value in [1,arg] */
 #define	POPT_ARGFLAG_TOGGLE	0x00200000U  /*!< permit --[no]opt prefix toggle */
 
-/*@}*/
-
-/** \ingroup popt
+/**
  * \name Callback modifiers
  */
-/*@{*/
 #define POPT_CBFLAG_PRE		0x80000000U  /*!< call the callback before parse */
 #define POPT_CBFLAG_POST	0x40000000U  /*!< call the callback after parse */
 #define POPT_CBFLAG_INC_DATA	0x20000000U  /*!< use data from the include line,
 					       not the subtable */
 #define POPT_CBFLAG_SKIPOPTION	0x10000000U  /*!< don't callback with option */
 #define POPT_CBFLAG_CONTINUE	0x08000000U  /*!< continue callbacks with option */
-/*@}*/
 
-/** \ingroup popt
+/**
  * \name Error return values
  */
-/*@{*/
 #define POPT_ERROR_NOARG	-10	/*!< missing argument */
 #define POPT_ERROR_BADOPT	-11	/*!< unknown option */
 #define POPT_ERROR_UNWANTEDARG	-12	/*!< option does not take an argument */
@@ -102,26 +92,21 @@
 #define	POPT_ERROR_NULLARG	-20	/*!< opt->arg should not be NULL */
 #define	POPT_ERROR_MALLOC	-21	/*!< memory allocation failed */
 #define	POPT_ERROR_BADCONFIG	-22	/*!< config file failed sanity test */
-/*@}*/
 
-/** \ingroup popt
+/**
  * \name poptBadOption() flags
  */
-/*@{*/
 #define POPT_BADOPTION_NOALIAS  (1U << 0)  /*!< don't go into an alias */
-/*@}*/
 
-/** \ingroup popt
+/**
  * \name poptGetContext() flags
  */
-/*@{*/
 #define POPT_CONTEXT_NO_EXEC	(1U << 0)  /*!< ignore exec expansions */
 #define POPT_CONTEXT_KEEP_FIRST	(1U << 1)  /*!< pay attention to argv[0] */
 #define POPT_CONTEXT_POSIXMEHARDER (1U << 2) /*!< options can't follow args */
 #define POPT_CONTEXT_ARG_OPTS	(1U << 4) /*!< return args as options with value 0 */
-/*@}*/
 
-/** \ingroup popt
+/**
  */
 struct poptOption {
     const char * longName;	/*!< may be NULL */
@@ -133,7 +118,7 @@ struct poptOption {
     const char * argDescrip;	/*!< argument description for autohelp */
 };
 
-/** \ingroup popt
+/**
  * A popt alias argument for poptAddAlias().
  */
 struct poptAlias {
@@ -143,7 +128,7 @@ struct poptAlias {
     const char ** argv;		/*!< must be free()able */
 };
 
-/** \ingroup popt
+/**
  * A popt alias or exec argument for poptAddItem().
  */
 typedef struct poptItem_s {
@@ -152,10 +137,9 @@ typedef struct poptItem_s {
     const char ** argv;		/*!< (alias) args, must be free()able. */
 } * poptItem;
 
-/** \ingroup popt
+/**
  * \name Auto-generated help/usage
  */
-/*@{*/
 
 /**
  * Empty table marker to enable displaying popt alias/exec options.
@@ -175,19 +159,18 @@ extern struct poptOption * poptHelpOptionsI18N;
 			0, "Help options:", NULL },
 
 #define POPT_TABLEEND { NULL, '\0', 0, NULL, 0, NULL, NULL }
-/*@}*/
 
-/** \ingroup popt
+/**
  */
 typedef struct poptContext_s * poptContext;
 
-/** \ingroup popt
+/**
  */
 #ifndef __cplusplus
 typedef struct poptOption * poptOption;
 #endif
 
-/** \ingroup popt
+/**
  */
 enum poptCallbackReason {
     POPT_CALLBACK_REASON_PRE	= 0, 
@@ -199,7 +182,7 @@ enum poptCallbackReason {
 extern "C" {
 #endif
 
-/** \ingroup popt
+/**
  * Table callback prototype.
  * @param con		context
  * @param reason	reason for callback
@@ -213,14 +196,14 @@ typedef void (*poptCallbackType) (poptContext con,
 		const char * arg,
 		const void * data);
 
-/** \ingroup popt
+/**
  * Destroy context.
  * @param con		context
  * @return		NULL always
  */
 poptContext poptFreeContext( poptContext con);
 
-/** \ingroup popt
+/**
  * Initialize popt context.
  * @param name		context name (usually argv[0] program name)
  * @param argc		no. of arguments
@@ -235,14 +218,14 @@ poptContext poptGetContext(
 		const struct poptOption * options,
 		unsigned int flags);
 
-/** \ingroup popt
+/**
  * Destroy context (alternative implementation).
  * @param con		context
  * @return		NULL always
  */
 poptContext poptFini( poptContext con);
 
-/** \ingroup popt
+/**
  * Initialize popt context (alternative implementation).
  * This routine does poptGetContext() and then poptReadConfigFiles().
  * @param argc		no. of arguments
@@ -255,58 +238,56 @@ poptContext poptInit(int argc, const char ** argv,
 		const struct poptOption * options,
 		const char * configPaths);
 
-/** \ingroup popt
+/**
  * Reinitialize popt context.
  * @param con		context
  */
 void poptResetContext(poptContext con);
 
-/** \ingroup popt
+/**
  * Return value of next option found.
  * @param con		context
  * @return		next option val, -1 on last item, POPT_ERROR_* on error
  */
 int poptGetNextOpt(poptContext con);
 
-/** \ingroup popt
+/**
  * Return next option argument (if any).
  * @param con		context
  * @return		option argument, NULL if no argument is available
  */
 char * poptGetOptArg(poptContext con);
 
-/** \ingroup popt
+/**
  * Return next argument.
  * @param con		context
  * @return		next argument, NULL if no argument is available
  */
 const char * poptGetArg(poptContext con);
 
-/** \ingroup popt
+/**
  * Peek at current argument.
  * @param con		context
  * @return		current argument, NULL if no argument is available
  */
-const char * poptPeekArg(poptContext con)
-	/*@*/;
+const char * poptPeekArg(poptContext con);
 
-/** \ingroup popt
+/**
  * Return remaining arguments.
  * @param con		context
  * @return		argument array, NULL terminated
  */
 const char ** poptGetArgs(poptContext con);
 
-/** \ingroup popt
+/**
  * Return the option which caused the most recent error.
  * @param con		context
  * @param flags
  * @return		offending option
  */
-const char * poptBadOption(poptContext con, unsigned int flags)
-	/*@*/;
+const char * poptBadOption(poptContext con, unsigned int flags);
 
-/** \ingroup popt
+/**
  * Add arguments to context.
  * @param con		context
  * @param argv		argument array, NULL terminated
@@ -314,7 +295,7 @@ const char * poptBadOption(poptContext con, unsigned int flags)
  */
 int poptStuffArgs(poptContext con, const char ** argv);
 
-/** \ingroup popt
+/**
  * Add alias to context.
  * @todo Pass alias by reference, not value.
  * @deprecated Use poptAddItem instead.
@@ -325,7 +306,7 @@ int poptStuffArgs(poptContext con, const char ** argv);
  */
 int poptAddAlias(poptContext con, struct poptAlias alias, int flags);
 
-/** \ingroup popt
+/**
  * Add alias/exec item to context.
  * @param con		context
  * @param newItem	alias/exec item to add
@@ -334,7 +315,7 @@ int poptAddAlias(poptContext con, struct poptAlias alias, int flags);
  */
 int poptAddItem(poptContext con, poptItem newItem, int flags);
 
-/** \ingroup popt
+/**
  * Test path/file for config file sanity (regular file, permissions etc)
  * @param fn		file name
  * @return		1 on OK, 0 on NOTOK.
@@ -353,7 +334,7 @@ int poptReadFile(const char * fn, char ** bp,
 		size_t * nbp, int flags);
 #define	POPT_READFILE_TRIMNEWLINES	1
 
-/** \ingroup popt
+/**
  * Read configuration file.
  * @param con		context
  * @param fn		file name to read
@@ -361,7 +342,7 @@ int poptReadFile(const char * fn, char ** bp,
  */
 int poptReadConfigFile(poptContext con, const char * fn);
 
-/** \ingroup popt
+/**
  * Read configuration file(s).
  * Colon separated files to read, looping over poptReadConfigFile().
  * Note that an '@' character preceding a path in the list will
@@ -372,7 +353,7 @@ int poptReadConfigFile(poptContext con, const char * fn);
  */
 int poptReadConfigFiles(poptContext con, const char * paths);
 
-/** \ingroup popt
+/**
  * Read default configuration from /etc/popt and $HOME/.popt.
  * @param con		context
  * @param useEnv	(unused)
@@ -380,7 +361,7 @@ int poptReadConfigFiles(poptContext con, const char * paths);
  */
 int poptReadDefaultConfig(poptContext con, int useEnv);
 
-/** \ingroup popt
+/**
  * Duplicate an argument array.
  * @note: The argument array is malloc'd as a single area, so only argv must
  * be free'd.
@@ -395,7 +376,7 @@ int poptDupArgv(int argc, const char **argv,
 		int * argcPtr,
 		const char *** argvPtr);
 
-/** \ingroup popt
+/**
  * Parse a string into an argument array.
  * The parse allows ', ", and \ quoting, but ' is treated the same as " and
  * both may include \ quotes.
@@ -409,7 +390,7 @@ int poptDupArgv(int argc, const char **argv,
 int poptParseArgvString(const char * s,
 		int * argcPtr, const char *** argvPtr);
 
-/** \ingroup popt
+/**
  * Parses an input configuration file and returns an string that is a 
  * command line.  For use with popt.  You must free the return value when done.
  *
@@ -457,14 +438,14 @@ this_is   =   fdsafdas
  */
 int poptConfigFileToString(FILE *fp, char ** argstrp, int flags);
 
-/** \ingroup popt
+/**
  * Return formatted error string for popt failure.
  * @param error		popt error
  * @return		error string
  */
 const char * poptStrerror(const int error);
 
-/** \ingroup popt
+/**
  * Limit search for executables.
  * @param con		context
  * @param path		single path to search for executables
@@ -472,7 +453,7 @@ const char * poptStrerror(const int error);
  */
 void poptSetExecPath(poptContext con, const char * path, int allowAbsolute);
 
-/** \ingroup popt
+/**
  * Print detailed description of options.
  * @param con		context
  * @param fp		output file handle
@@ -480,7 +461,7 @@ void poptSetExecPath(poptContext con, const char * path, int allowAbsolute);
  */
 void poptPrintHelp(poptContext con, FILE * fp, int flags);
 
-/** \ingroup popt
+/**
  * Print terse description of options.
  * @param con		context
  * @param fp		output file handle
@@ -488,22 +469,21 @@ void poptPrintHelp(poptContext con, FILE * fp, int flags);
  */
 void poptPrintUsage(poptContext con, FILE * fp, int flags);
 
-/** \ingroup popt
+/**
  * Provide text to replace default "[OPTION...]" in help/usage output.
  * @param con		context
  * @param text		replacement text
  */
 void poptSetOtherOptionHelp(poptContext con, const char * text);
 
-/** \ingroup popt
+/**
  * Return argv[0] from context.
  * @param con		context
  * @return		argv[0]
  */
-const char * poptGetInvocationName(poptContext con)
-	/*@*/;
+const char * poptGetInvocationName(poptContext con);
 
-/** \ingroup popt
+/**
  * Shuffle argv pointers to remove stripped args, returns new argc.
  * @param con		context
  * @param argc		no. of args


### PR DESCRIPTION
Since doxygen 1.8.16, opening and closing a group must not be done as C
comment but as doxygen command, so the current grouping is broken. The
grouping was originally added 20 years ago (in commit
02c43f2ea8c2d087b70e90309e2ba307dc3aad64) when popt was still part of
rpm codebase, so the grouping would've made sense to distinguish from
the rest of the codebase, but as popt is now standalone project, these
are just nonsensical. Rather than bother fixing, just remove.

Suggested-by: Alexander Traud <pabstraud@compuserve.com>
Fixes: #60