### PR TITLE
[RFC] Free memory in leftover array

### DIFF
--- a/src/popt.c
+++ b/src/popt.c
@@ -216,6 +216,9 @@ void poptResetContext(poptContext con)
     else
 	con->os->next = 0;
 
+    for (i = 0; i < con->numLeftovers; i++) {
+        con->leftovers[i] = _free(con->leftovers[i]);
+    }
     con->numLeftovers = 0;
     con->nextLeftover = 0;
     con->restLeftover = 0;
@@ -1534,7 +1537,7 @@ poptContext poptFreeContext(poptContext con)
     con->numExecs = 0;
 
     for (i = 0; i < con->numLeftovers; i++) {
-        con->leftovers[i] = _free(&con->leftovers[i]);
+        con->leftovers[i] = _free(con->leftovers[i]);
     }
     con->leftovers = _free(con->leftovers);
 


### PR DESCRIPTION
The fixup for leftovers https://github.com/rpm-software-management/popt/commit/7219e1ddc1e8606dda18c1105df0d45d8e8e0e09 / https://github.com/rpm-software-management/popt/pull/48 introduced some memory leaks.
Sadly in the mean time client applications have adopted and are free'ing these memory on their own.
So this change will break them. Introducing it with a soname bump might be a compromise.
For details see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=941814.
