### PR TITLE
Fix memory leak regressions in popt 1.18

### DIFF
--- a/src/popt.c
+++ b/src/popt.c
@@ -216,6 +216,9 @@ void poptResetContext(poptContext con)
     else
 	con->os->next = 0;
 
+    for (i = 0; i < con->numLeftovers; i++) {
+        con->leftovers[i] = _free(con->leftovers[i]);
+    }
     con->numLeftovers = 0;
     con->nextLeftover = 0;
     con->restLeftover = 0;
@@ -1534,7 +1537,7 @@ poptContext poptFreeContext(poptContext con)
     con->numExecs = 0;
 
     for (i = 0; i < con->numLeftovers; i++) {
-        con->leftovers[i] = _free(&con->leftovers[i]);
+        con->leftovers[i] = _free(con->leftovers[i]);
     }
     con->leftovers = _free(con->leftovers);
 


### PR DESCRIPTION
Fix memory leak regression introduced in commit
7219e1ddc1e8606dda18c1105df0d45d8e8e0e09. Free the actual content, not
the array multiple times, and free on reset.