### PR TITLE
Fix segfault regression when NLS is enabled but libintl.h cannot be f…

### DIFF
--- a/src/poptint.c
+++ b/src/poptint.c
@@ -38,7 +38,7 @@ POPT_next_char (const char *str)
 
 #if !defined(POPT_fprintf)	/* XXX lose all the goop ... */
 
-#if defined(HAVE_DCGETTEXT)
+#if defined(ENABLE_NLS) && defined(HAVE_LIBINTL_H) && defined(HAVE_DCGETTEXT)
 /*
  * Rebind a "UTF-8" codeset for popt's internal use.
  */

--- a/src/poptint.h
+++ b/src/poptint.h
@@ -146,7 +146,7 @@ const char *POPT_next_char (const char *str);
 #define _(foo) foo
 #endif
 
-#if defined(ENABLE_NLS) && defined(HAVE_DCGETTEXT)
+#if defined(ENABLE_NLS) && defined(HAVE_LIBINTL_H) && defined(HAVE_DCGETTEXT)
 #define D_(dom, str) POPT_dgettext(dom, str)
 #define POPT_(foo) D_("popt", foo)
 #else


### PR DESCRIPTION
…ound

popt 1.18, apparently commit 83302258da3d54257dffb01297131065c683aa90,
introduced a regression with a configuration where NLS is enabled but
libintl.h cannot be found.

Require libintl.h to be present for the translation machinery to be used.
This probably isn't the most optimal way to solve it, but not crashing is
much better than crashing...

Fixes: #32