### PR TITLE
Misc

### DIFF
--- a/src/popt.h
+++ b/src/popt.h
@@ -443,7 +443,7 @@ int poptConfigFileToString(FILE *fp, char ** argstrp, int flags);
  * @param error		popt error
  * @return		error string
  */
-const char * poptStrerror(const int error);
+const char * poptStrerror(int error);
 
 /**
  * Limit search for executables.

--- a/src/popthelp.c
+++ b/src/popthelp.c
@@ -442,7 +442,6 @@ static void singleOptionHelp(FILE * fp, columns_t columns,
     helpLength = strlen(help);
     while (helpLength > lineLength) {
 	const char * ch;
-	char format[16];
 
 	ch = help + lineLength - 1;
 	while (ch > help && !_isspaceptr(ch))
@@ -459,8 +458,7 @@ static void singleOptionHelp(FILE * fp, columns_t columns,
 	{   char * fmthelp = xstrdup(help);
 	    if (fmthelp) {
 		fmthelp[ch - help] = '\0';
-		sprintf(format, "%%s\n%%%ds", (int) indentLength);
-		POPT_fprintf(fp, format, fmthelp, " ");
+		POPT_fprintf(fp, "%s\n%*s", fmthelp, (int) indentLength, " ");
 		free(fmthelp);
 	    }
 	}


### PR DESCRIPTION
* Use string literal as format string

      popthelp.c:463:34: warning: format not a string literal, argument types not checked [-Wformat-nonliteral]
        463 |                 POPT_fprintf(fp, format, fmthelp, " ");
            |                                  ^~~~~~

* Drop superfluous const in function declaration
  The parameter error is of type `int`, which is passed by value.