### PR TITLE
configure.ac: remove require gettext version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,6 @@ AC_SEARCH_LIBS([setreuid], [ucb])
 AC_CHECK_FUNCS([getuid geteuid iconv mtrace secure_getenv __secure_getenv setreuid setuid stpcpy strerror vasprintf srandom glob_pattern_p mbsrtowcs])
 
 AM_GNU_GETTEXT_VERSION([0.19.8])
-AM_GNU_GETTEXT_REQUIRE_VERSION([0.19.8])
 AM_GNU_GETTEXT([external])
 AM_ICONV_LINK
 


### PR DESCRIPTION
This breaks compilation with OpenWrt:
./configure: line 13059: syntax error near unexpected token `0.19.8' ./configure: line 13059: `AM_GNU_GETTEXT_REQUIRE_VERSION(0.19.8)'

Fixes: bf8dd64e8aa0 ("Update gettext autoconf usage")