### PR TITLE
URL modernization

### DIFF
--- a/popt.3
+++ b/popt.3
@@ -80,7 +80,7 @@ option from an argument.
 .sp
 The popt library is highly portable and should work on any POSIX 
 platform.  The latest version is distributed with rpm and is always available
-from: ftp://ftp.rpm.org/pub/rpm/dist.
+from: http://ftp.rpm.org/popt/releases/.
 .sp
 It may be redistributed under the X consortium license, see the file COPYING
 in the popt source distribution for details.
@@ -804,7 +804,7 @@ RPM, a popular Linux package management program, makes heavy use
 of popt's features. Many of its command-line arguments are implemented
 through popt aliases, which makes RPM an excellent example of how to
 take advantage of the popt library. For more information on RPM, see
-http://www.rpm.org. The popt source code distribution includes test
+https://rpm.org. The popt source code distribution includes test
 program(s) which use all of the features of the popt libraries in
 various ways. If a feature isn't working for you, the popt test code
 is the first place to look.
@@ -828,4 +828,4 @@ Erik W. Troan (Addison-Wesley, 1998; ISBN 0-201-30821-5), Chapter 24.
 .sp
 .BR popt.ps " is a Postscript version of the above cited book "
 chapter. It can be found in the source archive for popt available at: 
-ftp://ftp.rpm.org/pub/rpm.
+http://ftp.rpm.org/popt/releases/.

--- a/src/popt.c
+++ b/src/popt.c
@@ -4,7 +4,7 @@
 
 /* (C) 1998-2002 Red Hat, Inc. -- Licensing details are in the COPYING
    file accompanying popt source distributions, available from
-   ftp://ftp.rpm.org/pub/rpm/dist */
+   http://ftp.rpm.org/popt/releases/ */
 
 #undef	MYDEBUG
 

--- a/src/popt.h
+++ b/src/popt.h
@@ -3,7 +3,7 @@
 
 /* (C) 1998-2000 Red Hat, Inc. -- Licensing details are in the COPYING
    file accompanying popt source distributions, available from 
-   ftp://ftp.rpm.org/pub/rpm/dist. */
+   http://ftp.rpm.org/popt/releases/. */
 
 #ifndef H_POPT
 #define H_POPT

--- a/src/poptconfig.c
+++ b/src/poptconfig.c
@@ -4,7 +4,7 @@
 
 /* (C) 1998-2002 Red Hat, Inc. -- Licensing details are in the COPYING
    file accompanying popt source distributions, available from 
-   ftp://ftp.rpm.org/pub/rpm/dist. */
+   http://ftp.rpm.org/popt/releases/. */
 
 #include "system.h"
 #include "poptint.h"

--- a/src/popthelp.c
+++ b/src/popthelp.c
@@ -6,7 +6,7 @@
 
 /* (C) 1998-2002 Red Hat, Inc. -- Licensing details are in the COPYING
    file accompanying popt source distributions, available from 
-   ftp://ftp.rpm.org/pub/rpm/dist. */
+   http://ftp.rpm.org/popt/releases/. */
 
 #include "system.h"
 

--- a/src/poptint.h
+++ b/src/poptint.h
@@ -4,7 +4,7 @@
 
 /* (C) 1998-2000 Red Hat, Inc. -- Licensing details are in the COPYING
    file accompanying popt source distributions, available from 
-   ftp://ftp.rpm.org/pub/rpm/dist. */
+   http://ftp.rpm.org/popt/releases/. */
 
 #ifndef H_POPTINT
 #define H_POPTINT

--- a/src/poptparse.c
+++ b/src/poptparse.c
@@ -4,7 +4,7 @@
 
 /* (C) 1998-2002 Red Hat, Inc. -- Licensing details are in the COPYING
    file accompanying popt source distributions, available from 
-   ftp://ftp.rpm.org/pub/rpm/dist. */
+   http://ftp.rpm.org/popt/releases/. */
 
 #include "system.h"
 

--- a/tests/test1.c
+++ b/tests/test1.c
@@ -1,6 +1,6 @@
 /* (C) 1998-2002 Red Hat, Inc. -- Licensing details are in the COPYING
    file accompanying popt source distributions, available from
-   ftp://ftp.rpm.org/pub/rpm/dist. */
+   http://ftp.rpm.org/popt/releases/. */
 
 #include "system.h"
 


### PR DESCRIPTION
ftp://ftp.rpm.org/pub/rpm/dist → http://ftp.rpm.org/popt/releases/