### PR TITLE
cmake: Add check for iconv support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,11 @@ foreach(inchdr ${OPTINCS})
 	chkhdr(${inchdr} FALSE)
 endforeach()
 
+find_package(Iconv)
+
+if (Iconv_FOUND)
+	add_compile_definitions(HAVE_ICONV)
+endif()
 
 add_subdirectory(src)
 add_subdirectory(po)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,8 @@ target_include_directories(popt PUBLIC
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
+target_link_libraries(popt PRIVATE Iconv::Iconv)
+
 set_target_properties(popt PROPERTIES
 	VERSION ${PROJECT_VERSION}
 	SOVERSION ${POPT_SOVERSION}


### PR DESCRIPTION
popt can optionally use iconv to support an expanded set of encodings, so we should detect and enable this when available.

Fixes #95 