### PR TITLE
cmake: Fix typo in pkgconfig file template

### DIFF
--- a/cmake/popt.pc.in
+++ b/cmake/popt.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=$(prefix)
 libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTAL_INCLUDEDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Version: @PROJECT_VERSION@


### PR DESCRIPTION
CMAKE_INSTAL_INCLUDEDIR --> CMAKE_INSTALL_INCLUDEDIR
This fixes path defined for includedir variable