### PR TITLE
cmake: Fix another typo in pkgconfig file template

### DIFF
--- a/cmake/popt.pc.in
+++ b/cmake/popt.pc.in
@@ -1,5 +1,5 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=$(prefix)
+exec_prefix=${prefix}
 libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 


### PR DESCRIPTION
Make sure all variables uses {} and not ()