### PR TITLE
option to create static lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,13 @@ project(popt
 	LANGUAGES C
 )
 
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+option(BUILD_STATIC_LIBS "Build static libraries" OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
 # Set soversion
 set(POPT_SOVERSION 0)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,12 @@ add_compile_definitions(POPT_SYSCONFDIR="${CMAKE_INSTALL_FULL_SYSCONFDIR}")
 add_compile_definitions(PACKAGE="${PROJECT_NAME}")
 
 # Setup library target
-add_library(popt SHARED
+
+if (NOT BUILD_STATIC_LIBS AND NOT BUILD_SHARED_LIBS)
+	message(FATAL_ERROR "Can't disable both shared and static libraries")
+endif()
+
+set(SOURCES
 	popt.c
 	poptconfig.c
 	popthelp.c
@@ -15,24 +20,37 @@ add_library(popt SHARED
 	system.h
 )
 
-target_include_directories(popt PUBLIC
-	$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
-	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
-
-if (Iconv_FOUND)
-	target_link_libraries(popt PRIVATE Iconv::Iconv)
+if (BUILD_SHARED_LIBS)
+	add_library(poptShared SHARED ${SOURCES})
+	set(shared_lib poptShared)
+	target_include_directories(poptShared PUBLIC
+		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+	)
+	if (Iconv_FOUND)
+		target_link_libraries(poptShared PRIVATE Iconv::Iconv)
+	endif()
+	set_target_properties(poptShared PROPERTIES
+		OUTPUT_NAME popt
+		VERSION ${PROJECT_VERSION}
+		SOVERSION ${POPT_SOVERSION}
+		PUBLIC_HEADER popt.h
+		LINK_FLAGS "-Wl,--no-undefined -Wl,--version-script,\"${PROJECT_SOURCE_DIR}/src/libpopt.vers\""
+	)
 endif()
 
-set_target_properties(popt PROPERTIES
-	VERSION ${PROJECT_VERSION}
-	SOVERSION ${POPT_SOVERSION}
-	C_STANDARD 99
-	C_STANDARD_REQUIRED ON
-	C_EXTENSIONS ON
-	PUBLIC_HEADER popt.h
-	LINK_FLAGS "-Wl,--no-undefined -Wl,--version-script,\"${PROJECT_SOURCE_DIR}/src/libpopt.vers\""
-)
+if (BUILD_STATIC_LIBS)
+	add_library(poptStatic STATIC ${SOURCES})
+	set(static_lib poptStatic)
+	target_include_directories(poptStatic PUBLIC
+		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+	)
+	set_target_properties(poptStatic PROPERTIES
+		OUTPUT_NAME popt
+		PUBLIC_HEADER popt.h
+	)
+endif()
 
 # Install the library
 configure_file(${PROJECT_SOURCE_DIR}/cmake/popt.pc.in ${CMAKE_BINARY_DIR}/popt.pc @ONLY)
@@ -41,7 +59,7 @@ install(FILES ${CMAKE_BINARY_DIR}/popt.pc
 	 DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
 
-install(TARGETS popt
+install(TARGETS ${shared_lib} ${static_lib}
 	EXPORT poptTargets
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 	PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,13 @@
+if (BUILD_SHARED_LIBS)
+	set(libpopt poptShared)
+else()
+	set(libpopt poptStatic)
+endif()
+
 # Set up macro for building and adding tests
 macro(BuildTest TESTNAME)
 	add_executable(${TESTNAME} EXCLUDE_FROM_ALL ${TESTNAME}.c)
-	target_link_libraries(${TESTNAME} PRIVATE popt)
+	target_link_libraries(${TESTNAME} PRIVATE ${libpopt})
 	add_test(${TESTNAME}_build ${CMAKE_COMMAND} --build "${CMAKE_BINARY_DIR}" --config "$<CONFIG>" --target ${TESTNAME})
 	set_tests_properties(${TESTNAME}_build PROPERTIES FIXTURES_SETUP testit_fixture)
 endmacro()


### PR DESCRIPTION
now it's possible to compile the static lib instead of the shared lib

cmake -DBUILD_SHARED_LIBS=OFF

```
# mkdir build ; cd build ; cmake  .. ; make
...
[100%] Linking C shared library libpopt.so
```
```
# mkdir build ; cd build ; cmake -DBUILD_SHARED_LIBS=OFF .. ; make
...
[100%] Linking C static library libpopt.a
```