### PR TITLE
src/CMakeLists.txt: link to iconv only if it has been found

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,9 @@ target_include_directories(popt PUBLIC
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_link_libraries(popt PRIVATE Iconv::Iconv)
+if (Iconv_FOUND)
+	target_link_libraries(popt PRIVATE Iconv::Iconv)
+endif()
 
 set_target_properties(popt PROPERTIES
 	VERSION ${PROJECT_VERSION}


### PR DESCRIPTION
fixes compilation when iconv is missing / not detected by cmake

the relevant code is already properly guarded by ifdefs