### PR TITLE
popt.h: include version info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ popt-*.tar.gz
 /po/quot.sed
 /po/remove-potcdate.sin
 /po/stamp-po
+
+src/popt.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,11 @@ cmake_minimum_required(VERSION 3.12)
 # Ensure built-in policies from CMake are used, (e.g. improved policies for macOS)
 cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 
+set(POPT_VERSION 1)
+set(POPT_REVISION 19)
+
 project(popt
-	VERSION 1.19
+	VERSION ${POPT_VERSION}.${POPT_REVISION}
 	DESCRIPTION "Portable library for parsing command line parameters"
 	LANGUAGES C
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Build the library
 
+configure_file(${PROJECT_SOURCE_DIR}/src/popt.h.in ${PROJECT_SOURCE_DIR}/src/popt.h @ONLY)
+
 # autotool compatibility stuff
 add_compile_definitions(POPT_SYSCONFDIR="${CMAKE_INSTALL_FULL_SYSCONFDIR}")
 add_compile_definitions(PACKAGE="${PROJECT_NAME}")

--- a/src/popt.h.in
+++ b/src/popt.h.in
@@ -10,6 +10,9 @@
 
 #include <stdio.h>			/* for FILE * */
 
+#define POPT_VERSION @POPT_VERSION@
+#define POPT_REVISION @POPT_REVISION@
+
 #define POPT_OPTION_DEPTH	10
 
 /**


### PR DESCRIPTION
ref  #105

set 2 variables and rename popt.h to popt.h.in so that there's no need to manually update popt.h, it will happen when running cmake... popt.h.in becomes popt.h (autotools style)

this is an example, what do you think? Maybe use POPT_MAJOR_VERSION, POPT_MINOR_VERSION instead?