### PR TITLE
Man-page: Improve example and add info about flags used in poptGetContext()

### DIFF
--- a/popt.3
+++ b/popt.3
@@ -301,6 +301,40 @@ POPT_CONTEXT_POSIXMEHARDER	Options cannot follow arguments
 POPT_CONTEXT_ARG_OPTS	Return the arguments as options of value 0
 .TE
 .sp
+Here is a more detailed discussion of each flag:
+.sp
+.TP
+.B POPT_CONTEXT_NO_EXEC
+This bit disables all uses of
+.BR exec "(2) from within the given popt context."
+.sp
+.TP
+.B POPT_CONTEXT_KEEP_FIRST
+By default, popt ignores the value in
+.I argv[0]
+as it is typically the name of the program being run rather than a command-line
+argument. Specifying this flag causes popt to treat
+.I argv[0]
+as an option.
+.sp
+.TP
+.B POPT_CONTEXT_POSIXMEHARDER
+When this flag is set, it is required that all options is placed before any
+arguments. This flag is also in effect if any of the environment variables
+.B POSIXLY_CORRECT
+or
+.B POSIX_ME_HARDER
+is set.
+.sp
+.TP
+.B POPT_CONTEXT_ARG_OPTS
+When this flag is set, all non-option arguments will get the value 0. This means
+that
+.B poptGetNextOpt()
+returns 0 for all non-option arguments, while
+.BR poptGetArg() " returns " NULL .
+.sp
+.PP
 .RB "A " poptContext " keeps track of which options have already been "
 parsed and which remain, among other things. If a program wishes to 
 restart option processing of a set of arguments, it can reset the 

--- a/popt.3
+++ b/popt.3
@@ -754,6 +754,7 @@ at least some of the features of the extremely rich popt library.
 void usage(poptContext optCon, int exitcode, char *error, char *addl) {
     poptPrintUsage(optCon, stderr, 0);
     if (error) fprintf(stderr, "%s: %s\\n", error, addl);
+    poptFreeContext(optCon);
     exit(exitcode);
 }
 
@@ -761,7 +762,7 @@ int main(int argc, char *argv[]) {
    int     c;            /* used for argument parsing */
    int     i = 0;        /* used for tracking options */
    int     speed = 0;    /* used in argument parsing to set speed */
-   int     raw = 0;      /* raw mode? */ 
+   int     raw = 0;      /* raw mode? */
    int     j;
    char    buf[BUFSIZ+1];
    const char *portname;
@@ -770,35 +771,33 @@ int main(int argc, char *argv[]) {
    struct poptOption optionsTable[] = {
       { "bps", 'b', POPT_ARG_INT, &speed, 0,
 	"signaling rate in bits-per-second", "BPS" },
-      { "crnl", 'c', 0, 0, 'c',
+      { "crnl", 'c', POPT_ARG_NONE, 0, 'c',
 	"expand cr characters to cr/lf sequences", NULL },
-      { "hwflow", 'h', 0, 0, 'h',
+      { "hwflow", 'h', POPT_ARG_NONE, 0, 'h',
 	"use hardware (RTS/CTS) flow control", NULL },
-      { "noflow", 'n', 0, 0, 'n',
+      { "noflow", 'n', POPT_ARG_NONE, 0, 'n',
 	"use no flow control", NULL },
-      { "raw", 'r', 0, &raw, 0,
+      { "raw", 'r', POPT_ARG_NONE, &raw, 0,
 	"don't perform any character conversions", NULL },
-      { "swflow", 's', 0, 0, 's',
+      { "swflow", 's', POPT_ARG_NONE, 0, 's',
 	"use software (XON/XOF) flow control", NULL } ,
       POPT_AUTOHELP
-      { NULL, 0, 0, NULL, 0 }
+      POPT_TABLEEND
     };
 
-   optCon = poptGetContext(NULL, argc, argv, optionsTable, 0);
+   optCon = poptGetContext(NULL, argc, (const char **) argv, optionsTable, 0);
    poptSetOtherOptionHelp(optCon, "[OPTIONS]* <port>");
 
-   if (argc < 2) {
-	poptPrintUsage(optCon, stderr, 0);
-	exit(1);
-   }
+   if (argc < 2)
+       usage(optCon, 1, 0, NULL);
 
    /* Now do options processing, get portname */
    while ((c = poptGetNextOpt(optCon)) >= 0) {
       switch (c) {
-       case 'c': 
-          buf[i++] = 'c';         
+       case 'c':
+          buf[i++] = 'c';
           break;
-       case 'h': 
+       case 'h':
           buf[i++] = 'h';
           break;
        case 's':
@@ -815,7 +814,7 @@ int main(int argc, char *argv[]) {
 
    if (c < -1) {
       /* an error occurred during option processing */
-      fprintf(stderr, "%s: %s\\n", 
+      fprintf(stderr, "%s: %s\\n",
               poptBadOption(optCon, POPT_BADOPTION_NOALIAS),
               poptStrerror(c));
       return 1;


### PR DESCRIPTION
man-page: Add information for flags used in `poptGetContext()`

---
man-page: Improve example

Changes following:
  - Free memory in usage().
  - Use POPT_TABLEEND macro when creating option table.
  - Use POPT_ARG_NONE instead of magic number in option table.
  - Cast 'argv' to const, fixes incompatible pointer warning.
  - Remove end-of-line whitespace.
  - Call usage() if to few command-line arguments.