### PR TITLE
Fix potential double-free in test3.c

### DIFF
--- a/tests/test3.c
+++ b/tests/test3.c
@@ -30,7 +30,11 @@ int main (int argc, char **argv) {
 
 	printf ("single string: '%s'\n", out);
 
-	poptParseArgvString (out, &newargc, &newargv);
+	ret = poptParseArgvString (out, &newargc, &newargv);
+	if (ret != 0) {
+	    printf ("cannot parse %s. ret=%d\n", out, ret);
+	    continue;
+	}
 
 	printf ("popt array: size=%d\n", newargc);
 	for (j = 0; j < newargc; j++)


### PR DESCRIPTION
The pointer to newargv passed to poptParseArgvString() may not be assigned to in case of an error, and it still may contain an address to already freed memory from the previous for loop iteration.

To fix, add a return value check, similar to the one above it for the out pointer.

Found by a static analyzer.