### PR TITLE
Instruct man(1) to run the 'tbl' preprocessor

### DIFF
--- a/popt.3
+++ b/popt.3
@@ -1,3 +1,5 @@
+'\" t
+.
 .TH POPT 3  "June 30, 1998" "" "Linux Programmer's Manual"
 .SH NAME
 popt \- Parse command line options


### PR DESCRIPTION
This is needed to get set the macro 'TW' with the table width. This was a new warning in groff 1.23.0

Can be tested with the command:
```shell
LC_ALL=C.UTF-8 MANROFFSEQ='' MANWIDTH=80 \
    man --warnings -E UTF-8 -l -Tutf8 -Z popt.3 > /dev/null
```