### PR TITLE
Fix  CVE-2026-18739: off-by-one error in poptStuffArgs()

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -12,9 +12,11 @@ RUN dnf -y install \
   make \
   gcc \
   binutils \
+  libasan \
+  libubsan \
   && dnf clean all
 
 COPY . .
 
-RUN cmake -S . -B ./build -DENABLE_WERROR=ON
+RUN cmake -S . -B ./build -DENABLE_WERROR=ON -DENABLE_ASAN=ON -DENABLE_UBSAN=ON
 CMD cd build && ctest --output-on-failure --force-new-ctest-process

--- a/src/popt.c
+++ b/src/popt.c
@@ -1668,7 +1668,7 @@ int poptStuffArgs(poptContext con, const char ** argv)
     int argc;
     int rc;
 
-    if ((con->os - con->optionStack) == POPT_OPTION_DEPTH)
+    if ((con->os - con->optionStack + 1) == POPT_OPTION_DEPTH)
 	return POPT_ERROR_OPTSTOODEEP;
 
     for (argc = 0; argv[argc]; argc++)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(TEST_PROGRAMS
 	test2
 	test3
 	tdict
+	tstuff
 )
 
 foreach (TESTPROG ${TEST_PROGRAMS})

--- a/tests/test1.c
+++ b/tests/test1.c
@@ -181,7 +181,10 @@ static void resetVars(void)
     if (aBits)
 	(void) poptBitsClr(aBits);
 
-    oStr = (char *) -1;
+    if (oStr != (char *) -1) {
+	free(oStr);
+	oStr = (char *) -1;
+    }
 
     singleDash = 0;
     pass2 = 0;
@@ -294,6 +297,7 @@ int main(int argc, const char ** argv)
     fprintf(stdout, "\n");
 
 exit:
+    resetVars();
     optCon = poptFreeContext(optCon);
 #if defined(HAVE_MCHECK_H) && defined(HAVE_MTRACE)
     muntrace();   /* Trace malloc only if MALLOC_TRACE=mtrace-output-file. */

--- a/tests/test1.c
+++ b/tests/test1.c
@@ -15,7 +15,9 @@ static void option_callback(UNUSED(poptContext con),
 }
 
 static int arg1 = 0;
-static const char * arg2 = "(none)";
+static char * const arg2_default = "(none)";
+static char * arg2 = arg2_default;
+static char * myarg2 = NULL;
 static int arg3 = 0;
 static int inc = 0;
 static int shortopt = 0;
@@ -86,7 +88,7 @@ static struct poptOption options[] = {
   { "arg1", '\0', 0, &arg1, 0, "First argument with a really long"
 	    " description. After all, we have to test argument help"
 	    " wrapping somehow, right?", NULL },
-  { "arg2", '2', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT, &arg2, 0,
+  { "arg2", '2', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT, &arg2, 222,
 	"Another argument", "ARG" },
   { "arg3", '3', POPT_ARG_INT, &arg3, 0,
 	"A third argument", "ANARG" },
@@ -153,8 +155,12 @@ static struct poptOption options[] = {
 
 static void resetVars(void)
 {
+    if (arg2 != arg2_default)
+	free(arg2);
+    free(myarg2);
     arg1 = 0;
-    arg2 = "(none)";
+    arg2 = arg2_default;
+    myarg2 = NULL;
     arg3 = 0;
     inc = 0;
     shortopt = 0;
@@ -211,15 +217,30 @@ int main(int argc, const char ** argv)
     poptSetExecPath(optCon, ".", 1);
 
 #if 1
-    while ((rc = poptGetNextOpt(optCon)) > 0)	/* Read all the options ... */
-	{}
+    while ((rc = poptGetNextOpt(optCon)) > 0) {	/* Read all the options ... */
+	if (rc == 222) {
+	    if (arg2 != arg2_default) {
+		free(arg2);
+		arg2 = arg2_default;
+	    }
+	}
+    }
 
     poptResetContext(optCon);			/* ... and then start over. */
     resetVars();
 #endif
 
     pass2 = 1;
-    if ((rc = poptGetNextOpt(optCon)) < -1) {
+    while ((rc = poptGetNextOpt(optCon)) > 0) {
+	if (rc == 222) {
+	    free(myarg2);
+	    myarg2 = strdup(arg2);
+	    if (arg2 != arg2_default)
+		free(arg2);
+	    arg2 = NULL;
+	}
+    }
+    if (rc < -1) {
 	fprintf(stderr, "test1: bad argument %s: %s\n",
 		poptBadOption(optCon, POPT_BADOPTION_NOALIAS),
 		poptStrerror(rc));
@@ -236,7 +257,7 @@ int main(int argc, const char ** argv)
 	goto exit;
     }
 
-    fprintf(stdout, "arg1: %d arg2: %s", arg1, arg2);
+    fprintf(stdout, "arg1: %d arg2: %s", arg1, myarg2 ? myarg2 : "(none)");
 
     if (arg3)
 	fprintf(stdout, " arg3: %d", arg3);

--- a/tests/testit.sh
+++ b/tests/testit.sh
@@ -175,6 +175,8 @@ run test1 "test1 - 61" "" -x=f1
 
 run test1 "test1 - 62" "arg1: 0 arg2: (none) aInt: 1" --randint=-1
 
+run tstuff "tstuff - 1" "-13"
+
 if ! [ -e test3-data ]; then
   # create symlink for running during 'make distcheck'
   ln -s "${srcdir}/test3-data" test3-data

--- a/tests/tstuff.c
+++ b/tests/tstuff.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+#include <popt.h>
+
+int main(int argc, char *argv[])
+{
+    poptContext ctx = poptGetContext(argv[0], argc, (const char **)argv, NULL, 0);
+    int rc = 0;
+    for (int i = 0; i < 100; ++i) {
+	const char *ea[] = { "a", NULL };
+	if ((rc = poptStuffArgs(ctx, ea)))
+	    break;
+    }
+    printf("%d\n", rc);
+
+    poptFreeContext(ctx);
+    return rc;
+}


### PR DESCRIPTION
The poptStuffArgs function only checks whether (con->os - con->optionStack) is equal to POPT_OPTION_DEPTH (10) before incrementing con->os, and does not increment the value by 1 to perform boundary pre-checking, as handleAlias does.

Add a new test program as a reproducer for this case.

Co-authored-by: Panu Matilainen <pmatilai@redhat.com>

Fixes: CVE-2026-18739