### PR TITLE
Fix CVE-2026-18839: underflows and overflows in help printout

### DIFF
--- a/src/popthelp.c
+++ b/src/popthelp.c
@@ -197,79 +197,60 @@ getArgDescrip(const struct poptOption * opt,
 
 /**
  * Display default value for an option.
- * @param lineLength	display positions remaining
  * @param opt		option(s)
  * @param translation_domain	translation domain
  * @return
  */
 static char *
-singleOptionDefaultValue(size_t lineLength,
+singleOptionDefaultValue(
 		const struct poptOption * opt,
 		/* FIX: i18n macros disabled with lclint */
 		const char * translation_domain)
 {
     const char * defstr = D_(translation_domain, "default");
-    char * le = malloc(4*lineLength + 1);
-    char * l = le;
+    char * l = NULL;
 
-    if (le == NULL) return NULL;	/* XXX can't happen */
-    *le = '\0';
-    *le++ = '(';
-    le = stpcpy(le, defstr);
-    *le++ = ':';
-    *le++ = ' ';
   if (opt->arg) {	/* XXX programmer error */
     poptArg arg = { .ptr = opt->arg };
     switch (poptArgType(opt)) {
     case POPT_ARG_VAL:
     case POPT_ARG_INT:
-	le += sprintf(le, "%d", arg.intp[0]);
+	POPT_asprintf(&l, "(%s: %d)", defstr, arg.intp[0]);
 	break;
     case POPT_ARG_SHORT:
-	le += sprintf(le, "%hd", arg.shortp[0]);
+	POPT_asprintf(&l, "(%s: %hd)", defstr, arg.shortp[0]);
 	break;
     case POPT_ARG_LONG:
-	le += sprintf(le, "%ld", arg.longp[0]);
+	POPT_asprintf(&l, "(%s: %ld)", defstr, arg.longp[0]);
 	break;
     case POPT_ARG_LONGLONG:
-	le += sprintf(le, "%lld", arg.longlongp[0]);
+	POPT_asprintf(&l, "(%s: %lld)", defstr, arg.longlongp[0]);
 	break;
     case POPT_ARG_FLOAT:
     {	double aDouble = (double) arg.floatp[0];
-	le += sprintf(le, "%g", aDouble);
+	POPT_asprintf(&l, "(%s: %g)", defstr, aDouble);
     }	break;
     case POPT_ARG_DOUBLE:
-	le += sprintf(le, "%g", arg.doublep[0]);
+	POPT_asprintf(&l, "(%s: %g)", defstr, arg.doublep[0]);
 	break;
     case POPT_ARG_MAINCALL:
-	le += sprintf(le, "%p", opt->arg);
+	POPT_asprintf(&l, "(%s: %p)", defstr, opt->arg);
 	break;
     case POPT_ARG_ARGV:
-	le += sprintf(le, "%p", opt->arg);
+	POPT_asprintf(&l, "(%s: %p)", defstr, opt->arg);
 	break;
     case POPT_ARG_STRING:
-    {	const char * s = arg.argv[0];
-	if (s == NULL)
-	    le = stpcpy(le, "null");
-	else {
-	    size_t limit = 4*lineLength - (le - l) - sizeof("\"\")");
-	    size_t slen;
-	    *le++ = '"';
-	    strncpy(le, s, limit); le[limit] = '\0'; le += (slen = strlen(le));
-	    if (slen == limit && s[limit])
-		le[-1] = le[-2] = le[-3] = '.';
-	    *le++ = '"';
-	}
-    }	break;
+	if (arg.argv[0])
+	    POPT_asprintf(&l, "(%s: \"%s\")", defstr, arg.argv[0]);
+	else
+	    POPT_asprintf(&l, "(%s: %s)", defstr, "null");
+	break;
     case POPT_ARG_NONE:
     default:
-	l = _free(l);
 	return NULL;
 	break;
     }
   }
-    *le++ = ')';
-    *le = '\0';
 
     return l;
 }
@@ -286,7 +267,9 @@ static void singleOptionHelp(FILE * fp, columns_t columns,
 		const char * translation_domain)
 {
     size_t maxLeftCol = columns->cur;
-    size_t indentLength = maxLeftCol + 5;
+    size_t indentLength = maxLeftCol + 5 < columns->max ?
+			maxLeftCol + 5 :
+			columns->max - (maxLeftCol % columns->max);
     size_t lineLength = columns->max - indentLength;
     const char * help = D_(translation_domain, opt->descrip);
     const char * argDescrip = getArgDescrip(opt, translation_domain);
@@ -347,7 +330,7 @@ static void singleOptionHelp(FILE * fp, columns_t columns,
 
 	/* Choose type of output */
 	if (F_ISSET(opt, SHOW_DEFAULT)) {
-	    defs = singleOptionDefaultValue(lineLength, opt, translation_domain);
+	    defs = singleOptionDefaultValue(opt, translation_domain);
 	    if (defs) {
 		char * t = malloc((help ? strlen(help) : 0) +
 				strlen(defs) + sizeof(" "));

--- a/src/poptint.c
+++ b/src/poptint.c
@@ -192,3 +192,41 @@ POPT_fprintf (FILE * stream, const char * format, ...)
 }
 
 #endif	/* !defined(POPT_fprintf) */
+
+int POPT_vasprintf(char **strp, const char *fmt, va_list ap)
+{
+    char * p = NULL;
+    va_list aq;
+
+    if (strp == NULL)
+	return -1;
+
+    va_copy(aq, ap);
+    int n = vsnprintf(NULL, 0, fmt, aq);
+    va_end(aq);
+
+    if (n >= 0) {
+	size_t nb = (size_t)n + 1;
+	if ((p = malloc(nb))) {
+	    va_copy(aq, ap);
+	    n = vsnprintf(p, nb, fmt, aq);
+	    va_end(aq);
+	} else {
+	    n = -1;
+ 	}
+    }
+    *strp = p;
+
+    return n;
+}
+
+int POPT_asprintf(char **strp, const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    int n = POPT_vasprintf(strp, fmt, ap);
+    va_end(ap);
+
+    return n;
+}

--- a/src/poptint.h
+++ b/src/poptint.h
@@ -10,6 +10,7 @@
 #define H_POPTINT
 
 #include <stdint.h>
+#include <stdarg.h>
 
 #define POPT_OPTION_DEPTH	10
 
@@ -137,6 +138,9 @@ const char *POPT_prev_char (const char *str);
 const char *POPT_next_char (const char *str);
 
 #endif
+
+int POPT_vasprintf(char **strp, const char *fmt, va_list ap);
+int POPT_asprintf(char **strp, const char *fmt, ...);
 
 #if defined(ENABLE_NLS) && defined(HAVE_LIBINTL_H)
 #include <libintl.h>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,9 @@ set(TEST_PROGRAMS
 	test1
 	test2
 	test3
+	test4-1
+	test4-2
+	test4-3
 	tdict
 	tstuff
 )

--- a/tests/test1.c
+++ b/tests/test1.c
@@ -51,7 +51,7 @@ static char * oStr = (char *) -1;
 static int singleDash = 0;
 
 static const char * lStr =
-"This tests default strings and exceeds the ... limit. "
+"This tests default strings and exceeds the former ... limit. "
 "123456789+123456789+123456789+123456789+123456789+ "
 "123456789+123456789+123456789+123456789+123456789+ "
 "123456789+123456789+123456789+123456789+123456789+ "

--- a/tests/test4-1.c
+++ b/tests/test4-1.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <popt.h>
+
+static char *arg2 = "meh";
+
+static struct poptOption options[] = {
+    { "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaargh",
+	    '\0', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT,
+	    &arg2, 0, "Second", NULL },
+
+    POPT_AUTOALIAS
+    POPT_AUTOHELP
+    POPT_TABLEEND
+};
+
+int main(int argc, const char *argv[])
+{
+    poptContext optCon = poptGetContext("test4", argc, argv, options, 0);
+
+    poptReadDefaultConfig(optCon, 0);
+
+    int rc = poptGetNextOpt(optCon);
+
+    if (rc < -1) {
+	fprintf(stderr, "%s: bad argument %s: %s\n",
+		argv[0], poptBadOption(optCon, POPT_BADOPTION_NOALIAS),
+		poptStrerror(rc));
+	goto exit;
+    }
+
+exit:
+    poptFreeContext(optCon);
+}

--- a/tests/test4-2.c
+++ b/tests/test4-2.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <popt.h>
+
+static char *arg3 = NULL;
+
+static struct poptOption options[] = {
+    { "brrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrgh",
+	    '\0', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT,
+	    &arg3, 0, "Third", NULL },
+
+    POPT_AUTOALIAS
+    POPT_AUTOHELP
+    POPT_TABLEEND
+};
+
+int main(int argc, const char *argv[])
+{
+    poptContext optCon = poptGetContext("test4", argc, argv, options, 0);
+
+    poptReadDefaultConfig(optCon, 0);
+
+    int rc = poptGetNextOpt(optCon);
+
+    if (rc < -1) {
+	fprintf(stderr, "%s: bad argument %s: %s\n",
+		argv[0], poptBadOption(optCon, POPT_BADOPTION_NOALIAS),
+		poptStrerror(rc));
+	goto exit;
+    }
+
+exit:
+    poptFreeContext(optCon);
+}

--- a/tests/test4-3.c
+++ b/tests/test4-3.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <popt.h>
+
+static char *arg2 = NULL;
+
+static struct poptOption options[] = {
+    { "aarrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrggggggh",
+	    '\0', POPT_ARG_STRING,
+	    &arg2, 0, "xxxxx", NULL },
+
+    POPT_AUTOALIAS
+    POPT_AUTOHELP
+    POPT_TABLEEND
+};
+
+int main(int argc, const char *argv[])
+{
+    poptContext optCon = poptGetContext("test4", argc, argv, options, 0);
+
+    poptReadDefaultConfig(optCon, 0);
+
+    int rc = poptGetNextOpt(optCon);
+
+    if (rc < -1) {
+	fprintf(stderr, "%s: bad argument %s: %s\n",
+		argv[0], poptBadOption(optCon, POPT_BADOPTION_NOALIAS),
+		poptStrerror(rc));
+	goto exit;
+    }
+
+exit:
+    poptFreeContext(optCon);
+}

--- a/tests/testit.sh
+++ b/tests/testit.sh
@@ -152,8 +152,8 @@ Usage: test1 [OPTION...]
       --nstr=STRING               POPT_ARG_STRING: (null) (default: null)
       --lstr=STRING               POPT_ARG_STRING: \"123456789...\" (default:
                                   \"This tests default strings and exceeds the
-                                  ... limit.
-                                  123456789+123456789+123456789+123456789+123456789+ 123456789+123456789+123456789+123456789+123456789+ 1234567...\")
+                                  former ... limit.
+                                  123456789+123456789+123456789+123456789+123456789+ 123456789+123456789+123456789+123456789+123456789+ 123456789+123456789+123456789+123456789+123456789+ 123456789+123456789+123456789+123456789+123456789+ \")
 
 arg for cb2
   -c, --cb2=STRING                Test argument callbacks
@@ -185,6 +185,30 @@ run_diff test3 "test3 - 1" test3-data/01.input test3-data/01.answer
 run_diff test3 "test3 - 2" test3-data/02.input test3-data/02.answer
 run_diff test3 "test3 - 3" test3-data/03.input test3-data/03.answer
 run_diff test3 "test3 - 5" test3-data/05.input test3-data/05.answer
+
+run test4-1 "test 4-1 - 63" "\
+Usage: test4-1 [OPTION...]
+      --aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaargh=STRING     Second (default: \"meh\")
+
+Help options:
+  -?, --help                                                                Show this help message
+      --usage                                                               Display brief usage message" --help
+
+run test4-2 "test 4-2 - 64" "\
+Usage: test4-2 [OPTION...]
+      --brrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrgh=STRING     Third (default: null)
+
+Help options:
+  -?, --help                                                                                                              Show this help message
+      --usage                                                                                                             Display brief usage message" --help
+
+run test4-3 "test 4-3 - 65" "\
+Usage: test4-3 [OPTION...]
+      --aarrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrggggggh=STRING     xxxxx
+
+Help options:
+  -?, --help                                                                   Show this help message
+      --usage                                                                  Display brief usage message" --help
 
 echo ""
 if [ $retval != 0 ]; then


### PR DESCRIPTION
Full details in commit messages, but the short summary of this is that the buffer and line length calculations are so wrong in so many ways it's not really worth trying to patch it up. Bring in an allocating sprintf() variant that does the job for us, and use it. Lo and behold, no more crashes.